### PR TITLE
[rectification] added 'epipolar_rectification' parameter and 'asp' matching algorithm

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,15 @@ the 'bin' folder:
 
     ln -s PATH_TO_YOUR_MICMAC_DIR bin/micmac
 
+### The NASA Ames Stereo Pipeline (ASP) (optional)
+### http://ti.arc.nasa.gov/tech/asr/intelligent-robotics/ngt/stereo/
+
+If you want to use ASP for the stereo matching step, you must install it (or
+download binaries) and add the bin folder (containing the executables 'stereo_corr',
+'stereo_rfne' and 'stereo_fltr') to PATH environment variable:
+
+    export PATH=PATH_TO_YOUR_ASP_BIN_DIR:$PATH
+
 ### Old dependencies. Not required anymore
 
 Here are the instuctions to install them in a local folder, without root

--- a/python/config.py
+++ b/python/config.py
@@ -66,6 +66,9 @@ cfg['epipolar_thresh'] = 0.5
 # hirschmuller08_laplacian', 'sgbm', 'mgm'
 cfg['matching_algorithm'] = 'mgm'
 
+# switch to False to disable epipolar rectification and rectify the secondary tile only
+cfg['epipolar_rectification'] = True
+
 # blur pleiades images before stereo matching
 cfg['use_pleiades_unsharpening'] = True
 

--- a/python/process.py
+++ b/python/process.py
@@ -363,15 +363,22 @@ def disparity(out_dir, img1, rpc1, img2, rpc2, x=None, y=None,
     disp_min_max = '%s/disp_min_max.txt' % out_dir
     config = '%s/config.json' % out_dir
 
+    # verifing non-epipolar_rectification is possible
+    algo = cfg['matching_algorithm']
+    if algo not in ['asp']:
+        cfg['epipolar_rectification'] = True
+
     # disparity (block-matching)
     disp_min, disp_max = np.loadtxt(disp_min_max)
 
-    if cfg['disp_min'] is not None:
-        disp_min = cfg['disp_min']
-    if cfg['disp_max'] is not None:
-        disp_max = cfg['disp_max']
+    if cfg['epipolar_rectification']:
+        if cfg['disp_min'] is not None:
+            disp_min = cfg['disp_min']
+        if cfg['disp_max'] is not None:
+            disp_max = cfg['disp_max']
+
     block_matching.compute_disparity_map(rect1, rect2, disp, mask,
-                                         cfg['matching_algorithm'], disp_min,
+                                         algo, disp_min,
                                          disp_max)
 
     # intersect mask with the cloud_water_image_domain mask (recomputed here to


### PR DESCRIPTION
Rectifying both tiles of the pair is necessary only if the block-matching algorithm is monodimensional.
This pull request allows to rectify only the second tile of the pair if the block-matching algorithm is two-dimensional. As an example, the interface with the algorithm ASP of the NASA is added.
