### PR TITLE
[srtm] removed downloading in srtm.c and added url with authorization

### DIFF
--- a/python/common.py
+++ b/python/common.py
@@ -8,6 +8,8 @@ import os
 import re
 import sys
 import urllib2
+import base64
+import urlparse
 import datetime
 import tempfile
 import subprocess
@@ -921,6 +923,30 @@ def which(program):
 
     return None
 
+def url_with_authorization_header(from_url):
+    """
+    Add authorization header
+
+    Args:
+        from_url: url of the file to download
+    """
+    scheme, netloc, path, param, query = urlparse.urlsplit(from_url)
+    if "@" in netloc:
+        userinfo = netloc.rsplit("@",1)[0]
+        if ":" in userinfo:
+            username = userinfo.rsplit(":",1)[0]
+            password = userinfo.rsplit(":",1)[1]
+            netloc = netloc.rsplit("@",1)[1]
+
+            from_url = urlparse.urlunsplit((scheme, netloc, path, param, query))
+
+            if username != None and password != None:
+                request = urllib2.Request(from_url)
+                base64string = base64.encodestring('%s:%s' % (username, password)).replace('\n', '')
+                request.add_header("Authorization", "Basic %s" % base64string)
+                from_url = request
+
+    return from_url
 
 def download(to_file, from_url):
     """

--- a/python/config.py
+++ b/python/config.py
@@ -103,7 +103,8 @@ cfg['mosaic_method'] = 'piio'
 
 # url of the srtm database mirror
 #cfg['srtm_url'] = 'http://138.231.80.250:443/srtm/tiff'
-cfg['srtm_url'] = 'ftp://xftp.jrc.it/pub/srtmV4/tiff'
+#cfg['srtm_url'] = 'ftp://xftp.jrc.it/pub/srtmV4/tiff'
+cfg['srtm_url'] = 'http://data_public:GDdci@data.cgiar-csi.org/srtm/tiles/GeoTIFF'
 
 # directory where to store the srtm tiles
 current_dir = os.path.dirname(os.path.abspath(__file__))

--- a/python/initialization.py
+++ b/python/initialization.py
@@ -157,26 +157,27 @@ def init_dirs_srtm(config_file):
     if not os.path.exists(cfg['out_dir']):
         os.makedirs(cfg['out_dir'])
 
-        if not os.path.exists( os.path.join(cfg['out_dir'],'dsm') ):
-            os.makedirs( os.path.join(cfg['out_dir'],'dsm') )
+    if not os.path.exists( os.path.join(cfg['out_dir'],'dsm') ):
+        os.makedirs( os.path.join(cfg['out_dir'],'dsm') )
 
-        if not os.path.exists(cfg['temporary_dir']):
-            os.makedirs(cfg['temporary_dir'])
+    if not os.path.exists(cfg['temporary_dir']):
+        os.makedirs(cfg['temporary_dir'])
 
-        if not os.path.exists(os.path.join(cfg['temporary_dir'], 'meta')):
-            os.makedirs(os.path.join(cfg['temporary_dir'], 'meta'))
-        f = open('%s/config.json' % cfg['out_dir'], 'w')
-        json.dump(cfg, f, indent=2)
-        f.close()
+    if not os.path.exists(os.path.join(cfg['temporary_dir'], 'meta')):
+        os.makedirs(os.path.join(cfg['temporary_dir'], 'meta'))
 
-        # duplicate stdout and stderr to log file
-        tee.Tee('%s/stdout.log' % cfg['out_dir'], 'w')
+    f = open('%s/config.json' % cfg['out_dir'], 'w')
+    json.dump(cfg, f, indent=2)
+    f.close()
 
-        # needed srtm tiles
-        srtm_tiles = srtm.list_srtm_tiles(cfg['images'][0]['rpc'],
-                                          *cfg['roi'].values())
-        for s in srtm_tiles:
-            srtm.get_srtm_tile(s, cfg['srtm_dir'])
+    # duplicate stdout and stderr to log file
+    tee.Tee('%s/stdout.log' % cfg['out_dir'], 'w')
+
+    # needed srtm tiles
+    srtm_tiles = srtm.list_srtm_tiles(cfg['images'][0]['rpc'],
+                                      *cfg['roi'].values())
+    for s in srtm_tiles:
+        srtm.get_srtm_tile(s, cfg['srtm_dir'])
 
 
 def init_tiles_full_info(config_file):

--- a/python/srtm.py
+++ b/python/srtm.py
@@ -60,6 +60,10 @@ def get_srtm_tile(srtm_tile, out_dir):
     # download the zip file
     srtm_tile_url = '%s/%s.zip' % (cfg['srtm_url'], srtm_tile)
     zip_path = os.path.join(out_dir, '%s.zip' % srtm_tile)
+
+    # add authorization header
+    srtm_tile_url = common.url_with_authorization_header(srtm_tile_url)
+
     common.download(zip_path, srtm_tile_url)
 
     # extract the tif file


### PR DESCRIPTION
This pull request removes the downloading of the srtm tiles on the fly by srtm4.c (better for offline context for example).
The srtm tiles must be downloaded during the preprocessing step.

The pull request allows to use url with authorization : 
ex : http://data_public:GDdci@data.cgiar-csi.org/srtm/tiles/GeoTIFF
