### PR TITLE
[rpc] add S7_SENSOR Tag support in RPC METADATA_PROFILE

### DIFF
--- a/python/rpc_model.py
+++ b/python/rpc_model.py
@@ -170,7 +170,7 @@ class RPCModel:
         a = tree.find('Metadata_Identification/METADATA_PROFILE') # PHR_SENSOR
         b = tree.find('IMD/IMAGE/SATID') # WorldView
         if a is not None:
-            if a.text in ['PHR_SENSOR', 'S6_SENSOR']:
+            if a.text in ['PHR_SENSOR', 'S6_SENSOR', 'S7_SENSOR']:
                 self.read_rpc_pleiades(tree)
             else:
                 print 'unknown sensor type'


### PR DESCRIPTION
SPOT7 and 6 data present a slight change in RPC  <METADATA_PROFILE> tag  : S7_SENSOR (instead of S6_SENSOR). In order to handle S7 sensor this tag has to be added in RPC model ingestion.
This is the purpose of this pull request.
