### PR TITLE
Fix dsm strips

### DIFF
--- a/c/plytodsm.c
+++ b/c/plytodsm.c
@@ -412,7 +412,7 @@ int main(int c, char *v[])
 		
 	if (nbply_pushed == 0)
 	{
-		fprintf(stderr, "ERROR : no ply file pushed\n", ply);
+		fprintf(stderr, "ERROR : no ply file pushed\n");
 		return 1;
 	}
 		

--- a/c/plytodsm.c
+++ b/c/plytodsm.c
@@ -321,7 +321,7 @@ static void add_ply_points_to_images(struct images *x,
 void help(char *s)
 {
 	fprintf(stderr, "usage:\n\t"
-			"%s [-c column] [-flag] resolution out_dsm list_of_tiles_txt xmin xmax ymin ymax\n", s);
+			"%s [-c column] [-flag] resolution out_dsm xmin xmax ymin ymax rowmin steprow rowmax colmin stepcol colmax tw th root_out_dir\n", s);
 	fprintf(stderr, "\t the resolution is in meters per pixel\n");
 }
 
@@ -333,7 +333,7 @@ int main(int c, char *v[])
 	int flag = atoi(pick_option(&c, &v, "flag", "0"));
 
 	// process input arguments
-	if (c != 8) {
+	if (c != 16) {
 		help(*v);
 		return 1;
 	}
@@ -341,18 +341,25 @@ int main(int c, char *v[])
 	char *out_dsm = v[2];
 	
 	
-	float xmin = atof(v[4]);
-	float xmax = atof(v[5]);
-	float ymin = atof(v[6]);
-	float ymax = atof(v[7]);
+	float xmin = atof(v[3]);
+	float xmax = atof(v[4]);
+	float ymin = atof(v[5]);
+	float ymax = atof(v[6]);
 	fprintf(stderr, "xmin: %20f, xmax: %20f, ymin: %20f, ymax: %20f\n", xmin,xmax,ymin,ymax);
+	int rowmin = atoi(v[7]);
+	int steprow = atoi(v[8]);
+	int rowmax = atoi(v[9]);
+	int colmin = atoi(v[10]);
+	int stepcol = atoi(v[11]);
+	int colmax = atoi(v[12]);
+	int tw = atoi(v[13]);
+	int th = atoi(v[14]);
+	char *root_out_dir=v[15];
 
 	// process each filename to determine x, y extremas and store the
 	// filenames in a list of strings, to be able to open the files again
-	FILE* list_tiles_file = NULL;
 	FILE* ply_extrema_file = NULL;
 	
-	char tile_dir[1000];
 	char ply[1000];
 	char ply_extrema[1000];
 	char utm[3];
@@ -363,13 +370,12 @@ int main(int c, char *v[])
 	
 	// From the list of tiles, find each ply file
 	uint64_t nbply_pushed=0;
-	list_tiles_file = fopen(v[3], "r");
-	if (list_tiles_file)
-	{
-	    while (fgets(tile_dir, 1000, list_tiles_file) != NULL)
+	int row,col;
+	for(row=rowmin;row<=rowmax;row+=steprow)
+	    for(col=colmin;col<=colmax;col+=stepcol)
 	    {
-	       strtok(tile_dir, "\n");
-	       sprintf(ply_extrema,"%s/plyextrema.txt",tile_dir);
+	       //strtok(tile_dir, "\n");
+	       sprintf(ply_extrema,"%s/tile_%d_%d_row_%d/col_%d/plyextrema.txt",root_out_dir,tw,th,row,col);
 	       
 	       // Now, find the extent of a given ply file, 
 	       // specified by [local_xmin local_xmax local_ymin local_ymax]
@@ -378,12 +384,12 @@ int main(int c, char *v[])
 	       {
 		  fscanf(ply_extrema_file, "%f %f %f %f", &local_xmin, &local_xmax, &local_ymin, &local_ymax);
 		  fclose(ply_extrema_file);
-		  
+
 		  // Only add ply files that intersect the extent specified by [xmin xmax ymin ymax]
 		  // The test below simply tells whether two rectancles overlap
 		  if ( (local_xmin <= xmax) && (local_xmax >= xmin) && (local_ymin <= ymax) && (local_ymax >= ymin) )
 		   {
-		       sprintf(ply,"%s/cloud.ply",tile_dir);
+		       sprintf(ply,"%s/tile_%d_%d_row_%d/col_%d/cloud.ply",root_out_dir,tw,th,row,col);
 		       // Record UTM zone
 		       FILE *ply_file = fopen(ply, "r");
 			if (ply_file) 
@@ -393,6 +399,7 @@ int main(int c, char *v[])
 			    int isbin=0;
 			    struct ply_property t[100];
 			    size_t n = header_get_record_length_and_utm_zone(ply_file, utm, &isbin, t);
+			    fclose(ply_file);
 			}
 			else
 			    fprintf(stderr, "WARNING 2 : can not open file \"%s\"\n", ply);
@@ -400,12 +407,7 @@ int main(int c, char *v[])
 	       }
 	       else
 		    fprintf(stderr,"WARNING 1 : can not open file %s\n",ply_extrema);
-
-	    } //end while (fgets(tile_dir, 1000, list_tiles_file) != NULL)
-	    fclose(list_tiles_file);
-	}
-	else
-	    fprintf(stderr,"ERROR : can not open file %s\n",v[3]);
+	    } //end for loops
 		
 		
 	if (nbply_pushed == 0)

--- a/python/initialization.py
+++ b/python/initialization.py
@@ -180,32 +180,13 @@ def init_dirs_srtm(config_file):
         srtm.get_srtm_tile(s, cfg['srtm_dir'])
 
 
-def init_tiles_full_info(config_file):
+def cutting(config_file):
     """
-    Prepare the entire process.
-
     1) Make sure coordinates of the ROI are multiples of the zoom factor
     2) Compute optimal size for tiles, get the number of pairs
-    3) Build tiles_full_info: a list of dictionaries, one per tile, providing all you need to process a tile
-       * col/row : position of the tile (upper left corner)
-       * tw/th : size of the tile
-       * ov : size of the overlapping
-       * i/j : relative position of the tile
-       * pos : position inside the ROI : UL for a tile place at th Upper Left corner, M for the ones placed in the middle, and so forth.
-       * x/y/w/h : information about the ROI
-       * images : a dictionary directly given by the json config file, that store the information about all the involved images, their rpc, and so forth.
-       * nb_pairs : number of pairs
-       * cld_msk/roi_msk : path to a gml file containing a cloud mask/ defining the area contained in the full image
-
-    Args:
-         config_file: path to a json configuration file
-
-    Returns:
-        tiles_full_info: list containing dictionaries
     """
-
     init_roi(config_file)
-
+    
     #Get ROI
     x = cfg['roi']['x']    
     y = cfg['roi']['y']
@@ -234,6 +215,33 @@ def init_tiles_full_info(config_file):
     print 'total number of tiles: %d (%d x %d)' % (nt, ntx, nty)
     nb_pairs = len(cfg['images']) - 1
     print 'total number of pairs: %d' % nb_pairs
+    
+    return (x,y,w,h,z,ov,tw,th,nb_pairs)
+
+
+def init_tiles_full_info(config_file):
+    """
+    Prepare the entire process.
+
+    Build tiles_full_info: a list of dictionaries, one per tile, providing all you need to process a tile
+       * col/row : position of the tile (upper left corner)
+       * tw/th : size of the tile
+       * ov : size of the overlapping
+       * i/j : relative position of the tile
+       * pos : position inside the ROI : UL for a tile place at th Upper Left corner, M for the ones placed in the middle, and so forth.
+       * x/y/w/h : information about the ROI
+       * images : a dictionary directly given by the json config file, that store the information about all the involved images, their rpc, and so forth.
+       * nb_pairs : number of pairs
+       * cld_msk/roi_msk : path to a gml file containing a cloud mask/ defining the area contained in the full image
+
+    Args:
+         config_file: path to a json configuration file
+
+    Returns:
+        tiles_full_info: list containing dictionaries
+    """
+
+    x,y,w,h,z,ov,tw,th,nb_pairs = cutting(config_file)
 
     # build tile_info dictionaries and store them in a list
     tiles_full_info = list()
@@ -241,6 +249,7 @@ def init_tiles_full_info(config_file):
     range_x = np.arange(x, x + w - ov, tw - ov)
     rowmin, rowmax = range_y[0], range_y[-1]
     colmin, colmax = range_x[0], range_x[-1]
+       
     for i, row in enumerate(range_y):
         for j, col in enumerate(range_x):
             # ensure that tile coordinates are multiples of the zoom factor
@@ -284,9 +293,5 @@ def init_tiles_full_info(config_file):
     if len(tiles_full_info) == 1:
         tiles_full_info[0]['position_type'] = 'Single'
 
-    cutting_info=open(os.path.join(cfg['out_dir'],'list_of_tiles.txt'),'w')
-    for tile_info in tiles_full_info:
-        cutting_info.write( '%s\n' % (tile_info['directory']))
-    cutting_info.close()
     
     return tiles_full_info

--- a/s2p.py
+++ b/s2p.py
@@ -265,11 +265,11 @@ def compute_dsm(args):
     Compute the DSMs
 
     Args: 
-         - args  ( <==> [number_of_tiles,current_tile])
+         - args  ( <==> [config_file,number_of_tiles,current_tile])
     """
     list_of_tiles_dir = os.path.join(cfg['out_dir'],'list_of_tiles.txt')
    
-    number_of_tiles,current_tile = args
+    config_file,number_of_tiles,current_tile = args
     
     dsm_dir = os.path.join(cfg['out_dir'],'dsm')
     out_dsm = os.path.join(dsm_dir,'dsm_%d.tif' % (current_tile) )
@@ -285,6 +285,15 @@ def compute_dsm(args):
     ymin = global_ymin + current_tile*tile_y_size
     ymax = ymin + tile_y_size
     
+    # cutting info
+    x,y,w,h,z,ov,tw,th,nb_pairs = initialization.cutting(config_file)
+    range_y = np.arange(y, y + h - ov, th - ov)
+    range_x = np.arange(x, x + w - ov, tw - ov)
+    colmin, rowmin, tw, th = common.round_roi_to_nearest_multiple(z, range_x[0], range_y[0], tw, th)
+    colint, rowint, tw, th = common.round_roi_to_nearest_multiple(z, range_x[1], range_y[1], tw, th)
+    colmax, rowmax, tw, th = common.round_roi_to_nearest_multiple(z, range_x[-1], range_y[-1], tw, th)
+    cutsinf = '%d %d %d %d %d %d %d %d' % (rowmin,rowint-rowmin,rowmax,colmin,colint-colmin,colmax,tw,th)
+    
     flags={}
     flags['average-orig']=0
     flags['average']=1
@@ -295,15 +304,16 @@ def compute_dsm(args):
     flag = "-flag %d" % ( flags.get(cfg['dsm_option'],0) )
     
     if (ymax <= global_ymax):
-        common.run("plytodsm %s %f %s %s %f %f %f %f" % ( 
+        common.run("plytodsm %s %f %s %f %f %f %f %s %s" % ( 
                                                  flag,
                                                  cfg['dsm_resolution'], 
                                                  out_dsm, 
-                                                 list_of_tiles_dir,
                                                  global_xmin,
                                                  global_xmax,
                                                  ymin,
-                                                 ymax))
+                                                 ymax,
+                                                 cutsinf,
+                                                 cfg['out_dir']))
                                                  
                                              
 def global_finalization(tiles_full_info):
@@ -416,7 +426,7 @@ def execute_job(config_file,params):
         if step == 6:#"compute_dsm" :
             print 'compute_dsm ...'
             current_tile=int(tile_dir.split('_')[1]) # for instance, dsm_2 becomes 2
-            compute_dsm([cfg['dsm_nb_tiles'],current_tile])
+            compute_dsm([config_file,cfg['dsm_nb_tiles'],current_tile])
             
         if step == 7:#"global_finalization":    
             print 'global finalization...'     


### PR DESCRIPTION
The way plytodsm builds dsm tiles relies on the fact that it can find the ply files produced during "processing" step. Plytodsm knows their locations thanks to the list_of_tiles.txt file, given as input. Then, the final location of a ply file is simply obtained by concatenating the path of a tile with "cloud.ply".

However, plytodsm doesn't work well on our cluster, since I/O nodes don't provide list_of_tiles.txt properly. That's why now the location of a given cloud.ply file is built internally, given a root directory, the size of the tiles, their mutual spacing and so on... 

Interesting parts of the code impacted by this PR are located here:
https://github.com/cpalmann/s2p/blob/fix-dsm-strips/c/plytodsm.c#L324
https://github.com/cpalmann/s2p/blob/fix-dsm-strips/c/plytodsm.c#L374
https://github.com/cpalmann/s2p/blob/fix-dsm-strips/s2p.py#L288, related to this one https://github.com/cpalmann/s2p/blob/fix-dsm-strips/python/initialization.py#L183
https://github.com/cpalmann/s2p/blob/fix-dsm-strips/s2p.py#L307 (new way to call plytodsm)
