### PR TITLE
Temporary data cleanup

### DIFF
--- a/python/common.py
+++ b/python/common.py
@@ -31,6 +31,12 @@ os.environ['TMPDIR'] = os.path.join(cfg['temporary_dir'], 'meta/')
 garbage = list()
 
 
+def remove_if_exists(target):
+    try:
+        os.remove(target)
+    except OSError:
+        pass
+
 def garbage_cleanup():
     """
     Removes all the files listed in the global variable 'garbage'.

--- a/python/config.py
+++ b/python/config.py
@@ -20,6 +20,9 @@ cfg['temporary_dir'] = "/tmp"
 # temporary files are erased when s2p terminates. Switch to False to keep them
 cfg['clean_tmp'] = True
 
+# clean-up all unnecessary data
+cfg['clean_intermediate'] = True
+
 # switch to True if you want to process the whole image
 cfg['full_img']  = False
 

--- a/python/process.py
+++ b/python/process.py
@@ -392,7 +392,7 @@ def disparity(out_dir, img1, rpc1, img2, rpc2, x=None, y=None,
         masking.intersection(mask, mask, cwid_msk_rect)
         masking.erosion(mask, mask, cfg['msk_erosion'])
     except OSError:
-        print "file %s not produced" % mask
+        print "file %s not produced" % mask 
 
 
 def triangulate(out_dir, img1, rpc1, img2, rpc2, x=None, y=None,

--- a/s2p.py
+++ b/s2p.py
@@ -255,6 +255,8 @@ def process_tile(tile_info):
         common.remove_if_exists(os.path.join(tile_dir,'local_minmax.txt'))
         common.remove_if_exists(os.path.join(tile_dir,'applied_minmax.txt'))
         common.remove_if_exists(os.path.join(tile_dir,'roi_color_ref.tif'))
+        common.remove_if_exists(os.path.join(tile_dir,'roi_ref_crop.tif'))
+        
 def global_extent(tiles_full_info):
     """
     Compute the global extent from the extrema of each ply file


### PR DESCRIPTION
This pull request is about reducing the size of the output dir by cleaning all intermediate data. A new json option is provided for that intent.

On the provided test dataset (data/test_data_pleiades_reunion/config.json) output directory size is 154 Mo with the master code and falls down to 54 Mo with this pull request and the cleaning option activated.

Gain will be even more important with tristereo data.
