### PR TITLE
Recursive vrt

### DIFF
--- a/python/common.py
+++ b/python/common.py
@@ -31,6 +31,12 @@ os.environ['TMPDIR'] = os.path.join(cfg['temporary_dir'], 'meta/')
 garbage = list()
 
 
+def remove_if_exists(target):
+    try:
+        os.remove(target)
+    except OSError:
+        pass
+
 def garbage_cleanup():
     """
     Removes all the files listed in the global variable 'garbage'.

--- a/python/config.py
+++ b/python/config.py
@@ -20,6 +20,9 @@ cfg['temporary_dir'] = "/tmp"
 # temporary files are erased when s2p terminates. Switch to False to keep them
 cfg['clean_tmp'] = True
 
+# clean-up all unnecessary data
+cfg['clean_intermediate'] = True
+
 # switch to True if you want to process the whole image
 cfg['full_img']  = False
 

--- a/python/config.py
+++ b/python/config.py
@@ -116,3 +116,6 @@ cfg['srtm_dir'] = os.path.join(parent_dir, '.srtm')
 
 # DSM options
 cfg['dsm_option'] = 'median'
+
+# Convert vrt to plain tiffs
+cfg['vrt_to_tiff'] = True

--- a/python/globalfinalization.py
+++ b/python/globalfinalization.py
@@ -76,7 +76,11 @@ def write_vrt_files(tiles_full_info):
     z = cfg['subsampling_factor']
     tile_composer.mosaic_gdal2(cfg['out_dir'] + '/heightMap_N_pairs.vrt',
                                tileSizesAndPositions, 'local_merged_height_map_crop.tif', fw, fh, z)
-
+    if(cfg['clean_intermediate'] and cfg['vrt_to_tiff']):
+        for tile_dir in tileSizesAndPositions:
+            common.remove_if_exists(os.path.join(tile_dir,'local_merged_height_map_crop.tif'))
+        common.remove_if_exists(cfg['out_dir'] + '/heightMap_N_pairs.vrt')
+        
     # VRT file : height map (for each single pair)
     # VRT file : rpc_err (for each single pair)
     for i in range(0, nb_pairs):
@@ -91,10 +95,21 @@ def write_vrt_files(tiles_full_info):
 
         tile_composer.mosaic_gdal2(cfg['out_dir'] + '/heightMap_pair_%d.vrt' % (
             pair_id), pairSizesAndPositions, 'height_map_crop.tif', fw, fh, z)
+
+        if(cfg['clean_intermediate'] and cfg['vrt_to_tiff']):
+            for tile_dir in tileSizesAndPositions:
+                common.remove_if_exists(os.path.join(tile_dir,'height_map_crop.tif'))
+            common.remove_if_exists(cfg['out_dir'] +'/heightMap_pair_%d.vrt' % (pair_id))
+        
         tile_composer.mosaic_gdal2(cfg['out_dir'] + '/rpc_err_pair_%d.vrt' % (
             pair_id), pairSizesAndPositions, 'rpc_err_crop.tif', fw, fh, z)
 
-
+        if(cfg['clean_intermediate'] and cfg['vrt_to_tiff']):
+            for tile_dir in tileSizesAndPositions:
+                common.remove_if_exists(os.path.join(tile_dir,'rpc_err_crop.tif'))
+            common.remove_if_exists(cfg['out_dir'] +'/rpc_err_pair_%d.vrt' % (pair_id))
+        
+        
 def write_dsm():
     """
     Writes the DSM, from the ply files given by each tile.
@@ -105,6 +120,10 @@ def write_dsm():
 
     if cfg['vrt_to_tiff']:
         common.run('gdal_translate %s %s' % (final_dsm, os.path.splitext(final_dsm)[0]+".tif"))
+        if cfg['clean_intermediate']:
+            shutil.rmtree(os.path.join(cfg['out_dir'],'dsm'))
+            common.remove_if_exists(final_dsm);
+                          
 
 def lidar_preprocessor(output, input_plys):
     """

--- a/python/globalfinalization.py
+++ b/python/globalfinalization.py
@@ -103,6 +103,8 @@ def write_dsm():
     final_dsm = os.path.join(cfg['out_dir'], 'dsm.vrt')
     common.run("gdalbuildvrt %s %s" % (final_dsm, dsm_pieces))
 
+    if cfg['vrt_to_tiff']:
+        common.run('gdal_translate %s %s' % (final_dsm, os.path.splitext(final_dsm)[0]+".tif"))
 
 def lidar_preprocessor(output, input_plys):
     """

--- a/python/process.py
+++ b/python/process.py
@@ -392,7 +392,7 @@ def disparity(out_dir, img1, rpc1, img2, rpc2, x=None, y=None,
         masking.intersection(mask, mask, cwid_msk_rect)
         masking.erosion(mask, mask, cfg['msk_erosion'])
     except OSError:
-        print "file %s not produced" % mask
+        print "file %s not produced" % mask 
 
 
 def triangulate(out_dir, img1, rpc1, img2, rpc2, x=None, y=None,

--- a/python/tile_composer.py
+++ b/python/tile_composer.py
@@ -135,8 +135,9 @@ def mosaic_gdal2(fout, tiles_full_info, filename, w,h,z=1):
     vrtfile.write("\t</VRTRasterBand>\n")
     vrtfile.write("</VRTDataset>\n")
     vrtfile.close()
-                      
-    #common.run('gdal_translate %s %s' % (vrtfilename, fout))
+
+    if cfg['vrt_to_tiff']:
+        common.run('gdal_translate %s %s' % (vrtfilename, os.path.splitext(vrtfilename)[0]+".tif"))
 
     return
 

--- a/python/tile_composer.py
+++ b/python/tile_composer.py
@@ -86,6 +86,8 @@ def mosaic_gdal2(fout, tiles_full_info, filename, w,h,z=1):
 
     tw = 0
     th = 0
+
+    files_to_remove = []
     
     for tile_dir in tiles_full_info:
         
@@ -97,6 +99,7 @@ def mosaic_gdal2(fout, tiles_full_info, filename, w,h,z=1):
         height_map = os.path.join(*s[1:])
 
         if os.path.isfile(os.path.join(cfg['out_dir'],vrt_row[row]['vrt_dir'],height_map)):
+            files_to_remove.append(os.path.join(cfg['out_dir'],vrt_row[row]['vrt_dir'],height_map))
             vrt_row[row]['vrt_body']+="\t\t<SimpleSource>\n"
             vrt_row[row]['vrt_body']+="\t\t\t<SourceFilename relativeToVRT=\"1\">%s</SourceFilename>\n" % height_map
             vrt_row[row]['vrt_body']+="\t\t\t<SourceBand>1</SourceBand>\n"
@@ -114,6 +117,7 @@ def mosaic_gdal2(fout, tiles_full_info, filename, w,h,z=1):
     for row,vrt_data in vrt_row.iteritems():
         # First, write row vrt file
         col_vrt_filename = os.path.join(cfg['out_dir'],vrt_data['vrt_dir'],os.path.basename(vrtfilename))
+        files_to_remove.append(col_vrt_filename)
         tmp_vrt_file = open(col_vrt_filename,'w')
         tmp_vrt_file.write("<VRTDataset rasterXSize=\"%i\" rasterYSize=\"%i\">\n" % (w/z,
                                                                             th/z))
@@ -139,6 +143,9 @@ def mosaic_gdal2(fout, tiles_full_info, filename, w,h,z=1):
     if cfg['vrt_to_tiff']:
         common.run('gdal_translate %s %s' % (vrtfilename, os.path.splitext(vrtfilename)[0]+".tif"))
 
+        if cfg['clean_intermediate']:
+            for f in files_to_remove:
+                common.remove_if_exists(f)
     return
 
 

--- a/python/tile_composer.py
+++ b/python/tile_composer.py
@@ -81,33 +81,61 @@ def mosaic_gdal2(fout, tiles_full_info, filename, w,h,z=1):
     Returns:
         nothing
     """
-    vrtfilename = fout
+    
+    vrt_row = {}
 
-    vrtfile = open(vrtfilename, 'w')
-
-    vrtfile.write("<VRTDataset rasterXSize=\"%i\" rasterYSize=\"%i\">\n" % (w/z,
-                                                                            h/z))
-    vrtfile.write("\t<VRTRasterBand dataType=\"Float32\" band=\"1\">\n")
-    vrtfile.write("\t\t<ColorInterp>Gray</ColorInterp>\n")
-
+    tw = 0
+    th = 0
+    
     for tile_dir in tiles_full_info:
         
         col,row,tw,th=tiles_full_info[tile_dir]
-        
-        height_map = os.path.join(tile_dir,filename)
 
-        if os.path.isfile(os.path.join(cfg['out_dir'],height_map)):
-            vrtfile.write("\t\t<SimpleSource>\n")
-            vrtfile.write("\t\t\t<SourceFilename relativeToVRT=\"1\">%s</SourceFilename>\n" % height_map)
-            vrtfile.write("\t\t\t<SourceBand>1</SourceBand>\n")
-            vrtfile.write("\t\t\t<SrcRect xOff=\"%i\" yOff=\"%i\" xSize=\"%i\" ySize=\"%i\"/>\n" % (0, 0, tw/z, th/z))
-            vrtfile.write("\t\t\t<DstRect xOff=\"%i\" yOff=\"%i\" xSize=\"%i\" ySize=\"%i\"/>\n" % (col/z, row/z, tw/z, th/z))
-            vrtfile.write("\t\t</SimpleSource>\n")
+        vrt_row.setdefault(row,{'vrt_body' : "",'vrt_dir' : tile_dir.split('/')[0]})
+        height_map = os.path.join(tile_dir,filename)
+        s = height_map.split("/")
+        height_map = os.path.join(*s[1:])
+
+        if os.path.isfile(os.path.join(cfg['out_dir'],vrt_row[row]['vrt_dir'],height_map)):
+            vrt_row[row]['vrt_body']+="\t\t<SimpleSource>\n"
+            vrt_row[row]['vrt_body']+="\t\t\t<SourceFilename relativeToVRT=\"1\">%s</SourceFilename>\n" % height_map
+            vrt_row[row]['vrt_body']+="\t\t\t<SourceBand>1</SourceBand>\n"
+            vrt_row[row]['vrt_body']+="\t\t\t<SrcRect xOff=\"%i\" yOff=\"%i\" xSize=\"%i\" ySize=\"%i\"/>\n" % (0, 0, tw/z, th/z)
+            vrt_row[row]['vrt_body']+="\t\t\t<DstRect xOff=\"%i\" yOff=\"%i\" xSize=\"%i\" ySize=\"%i\"/>\n" % (col/z, 0, tw/z, th/z)
+            vrt_row[row]['vrt_body']+="\t\t</SimpleSource>\n"
+
+    vrtfilename = fout
+    vrtfile = open(vrtfilename, 'w')
+    vrtfile.write("<VRTDataset rasterXSize=\"%i\" rasterYSize=\"%i\">\n" % (w/z,h/z))
+    vrtfile.write("\t<VRTRasterBand dataType=\"Float32\" band=\"1\">\n")
+    vrtfile.write("\t\t<ColorInterp>Gray</ColorInterp>\n")
+    
+    
+    for row,vrt_data in vrt_row.iteritems():
+        # First, write row vrt file
+        col_vrt_filename = os.path.join(cfg['out_dir'],vrt_data['vrt_dir'],os.path.basename(vrtfilename))
+        tmp_vrt_file = open(col_vrt_filename,'w')
+        tmp_vrt_file.write("<VRTDataset rasterXSize=\"%i\" rasterYSize=\"%i\">\n" % (w/z,
+                                                                            th/z))
+        tmp_vrt_file.write("\t<VRTRasterBand dataType=\"Float32\" band=\"1\">\n")
+        tmp_vrt_file.write("\t\t<ColorInterp>Gray</ColorInterp>\n")
+        tmp_vrt_file.write(vrt_data['vrt_body'])
+        tmp_vrt_file.write("\t</VRTRasterBand>\n")
+        tmp_vrt_file.write("</VRTDataset>\n")
+        tmp_vrt_file.close()
+                
+        # Next, write entry in final vrt file
+        vrtfile.write("\t\t<SimpleSource>\n")
+        vrtfile.write("\t\t\t<SourceFilename relativeToVRT=\"1\">%s</SourceFilename>\n" % os.path.join(vrt_data['vrt_dir'],os.path.basename(vrtfilename)))
+        vrtfile.write("\t\t\t<SourceBand>1</SourceBand>\n")
+        vrtfile.write("\t\t\t<SrcRect xOff=\"%i\" yOff=\"%i\" xSize=\"%i\" ySize=\"%i\"/>\n" % (0, 0, w/z, th/z))
+        vrtfile.write("\t\t\t<DstRect xOff=\"%i\" yOff=\"%i\" xSize=\"%i\" ySize=\"%i\"/>\n" % (0, row/z, w/z, th/z))
+        vrtfile.write("\t\t</SimpleSource>\n")
 
     vrtfile.write("\t</VRTRasterBand>\n")
     vrtfile.write("</VRTDataset>\n")
     vrtfile.close()
-
+                      
     #common.run('gdal_translate %s %s' % (vrtfilename, fout))
 
     return

--- a/python/tile_composer.py
+++ b/python/tile_composer.py
@@ -93,7 +93,7 @@ def mosaic_gdal2(fout, tiles_full_info, filename, w,h,z=1):
         
         col,row,tw,th=tiles_full_info[tile_dir]
 
-        vrt_row.setdefault(row,{'vrt_body' : "",'vrt_dir' : tile_dir.split('/')[0]})
+        vrt_row.setdefault(row,{'vrt_body' : "",'vrt_dir' : tile_dir.split('/')[0], 'th' : th})
         height_map = os.path.join(tile_dir,filename)
         s = height_map.split("/")
         height_map = os.path.join(*s[1:])
@@ -115,6 +115,7 @@ def mosaic_gdal2(fout, tiles_full_info, filename, w,h,z=1):
     
     
     for row,vrt_data in vrt_row.iteritems():
+        th = vrt_data['th']
         # First, write row vrt file
         col_vrt_filename = os.path.join(cfg['out_dir'],vrt_data['vrt_dir'],os.path.basename(vrtfilename))
         files_to_remove.append(col_vrt_filename)

--- a/s2p.py
+++ b/s2p.py
@@ -255,6 +255,8 @@ def process_tile(tile_info):
         common.remove_if_exists(os.path.join(tile_dir,'local_minmax.txt'))
         common.remove_if_exists(os.path.join(tile_dir,'applied_minmax.txt'))
         common.remove_if_exists(os.path.join(tile_dir,'roi_color_ref.tif'))
+        common.remove_if_exists(os.path.join(tile_dir,'roi_ref_crop.tif'))
+        
 def global_extent(tiles_full_info):
     """
     Compute the global extent from the extrema of each ply file


### PR DESCRIPTION
gdal has difficulties reading vrt files with 10 000+ tiles. This pull request provides a recursive strategy which first builds one vrt per row, and then a global vrt of the collection of row vrt, to workaround this limitation.

Also, a vrt_to_tif option is added, in order to actually produce the output tif if wanted. In this case, if the cleaning option is activated, the source tiles are cleaned, which results in avoiding to duplicate data with the global tiff.
