### PR TITLE
Easier parrallel jobs

### DIFF
--- a/s2p.py
+++ b/s2p.py
@@ -395,6 +395,13 @@ def main(config_file, steps=ALL_STEPS):
     tw, th = initialization.adjust_tile_size()
     print('\ndiscarding masked tiles...')
     tiles = initialization.tiles_full_info(tw, th)
+
+    if 'initialisation' in steps:
+        # Write the list of json files to outdir/tiles.txt
+        with open(os.path.join(cfg['out_dir'],'tiles.txt'),'w') as f:
+            for t in tiles:
+                f.write(t['json']+os.linesep)
+
     n = len(cfg['images'])
     tiles_pairs = [(t, i) for i in range(1, n) for t in tiles]
 

--- a/s2p.py
+++ b/s2p.py
@@ -217,7 +217,7 @@ def disparity_to_ply(tile):
     Args:
         tile: dictionary containing the information needed to process a tile.
     """
-    out_dir = tile['dir']
+    out_dir = os.path.join(tile['dir'])
     ply_file = os.path.join(out_dir, 'cloud.ply')
     x, y, w, h = tile['coordinates']
 
@@ -228,11 +228,12 @@ def disparity_to_ply(tile):
     print('triangulating tile {} {}...'.format(x, y))
     rpc1 = cfg['images'][0]['rpc']
     rpc2 = cfg['images'][1]['rpc']
-    H_ref = os.path.join(out_dir, 'H_ref.txt')
-    H_sec = os.path.join(out_dir, 'H_sec.txt')
-    pointing = os.path.join(cfg['out_dir'], 'global_pointing.txt')
-    disp = os.path.join(out_dir, 'rectified_disp.tif')
-    mask_rect = os.path.join(out_dir, 'rectified_mask.png')
+    # This function is only called when there is a single pair (pair_1)
+    H_ref = os.path.join(out_dir,'pair_1', 'H_ref.txt')
+    H_sec = os.path.join(out_dir,'pair_1', 'H_sec.txt')
+    pointing = os.path.join(cfg['out_dir'], 'global_pointing_pair_1.txt')
+    disp = os.path.join(out_dir,'pair_1', 'rectified_disp.tif')
+    mask_rect = os.path.join(out_dir,'pair_1', 'rectified_mask.png')
     mask_orig = os.path.join(out_dir, 'cloud_water_image_domain_mask.png')
 
     # prepare the image needed to colorize point cloud
@@ -247,7 +248,7 @@ def disparity_to_ply(tile):
                                       hh + 2*cfg['vertical_margin'])
         common.image_qauto(tmp, colors)
     else:
-        common.image_qauto(os.path.join(out_dir, 'rectified_ref.tif'), colors)
+        common.image_qauto(os.path.join(out_dir,'pair_1', 'rectified_ref.tif'), colors)
 
     # compute the point cloud
     triangulation.disp_map_to_point_cloud(ply_file, disp, mask_rect, rpc1, rpc2,

--- a/s2plib/initialization.py
+++ b/s2plib/initialization.py
@@ -239,9 +239,6 @@ def tiles_full_info(tw, th):
             tiles.append(tile)
 
     # make tiles directories and store json configuration dumps
-
-    # Store the list config.json for all tiles  
-    json_list = []
     
     for tile in tiles:
         common.mkdir_p(tile['dir'])
@@ -256,7 +253,7 @@ def tiles_full_info(tw, th):
         tile_cfg['omp_num_threads'] = 1
 
         tile_json = os.path.join(tile['dir'], 'config.json') 
-        json_list.append(tile_json)
+        tile['json']=tile_json
         
         with open(tile_json, 'w') as f:
             json.dump(tile_cfg, f, indent=2)
@@ -265,10 +262,5 @@ def tiles_full_info(tw, th):
         piio.write(os.path.join(tile['dir'],
                                 'cloud_water_image_domain_mask.png'),
                    tile['mask'].astype(np.uint8))
-
-        # Write the list of json files to outdir/tiles.txt
-        with open(os.path.join(cfg['out_dir'],'tiles.txt'),'w') as f:
-            for line in json_list:
-                f.write(line+os.linesep)
             
     return tiles

--- a/s2plib/initialization.py
+++ b/s2plib/initialization.py
@@ -239,6 +239,10 @@ def tiles_full_info(tw, th):
             tiles.append(tile)
 
     # make tiles directories and store json configuration dumps
+
+    # Store the list config.json for all tiles  
+    json_list = []
+    
     for tile in tiles:
         common.mkdir_p(tile['dir'])
         if len(cfg['images']) > 2:
@@ -251,7 +255,11 @@ def tiles_full_info(tw, th):
         tile_cfg['roi'] = {'x': x, 'y': y, 'w': w, 'h': h}
         tile_cfg['max_processes'] = 1
         tile_cfg['omp_num_threads'] = 1
-        with open(os.path.join(tile['dir'], 'config.json'), 'w') as f:
+
+        tile_json = os.path.join(tile['dir'], 'config.json') 
+        json_list.append(tile_json)
+        
+        with open(tile_json, 'w') as f:
             json.dump(tile_cfg, f, indent=2)
 
         # save the mask
@@ -259,4 +267,9 @@ def tiles_full_info(tw, th):
                                 'cloud_water_image_domain_mask.png'),
                    tile['mask'].astype(np.uint8))
 
+        # Write the list of json files to outdir/tiles.txt
+        with open(os.path.join(cfg['out_dir'],'tiles.txt'),'w') as f:
+            for line in json_list:
+                f.write(line+os.linesep)
+            
     return tiles

--- a/s2plib/initialization.py
+++ b/s2plib/initialization.py
@@ -245,9 +245,8 @@ def tiles_full_info(tw, th):
     
     for tile in tiles:
         common.mkdir_p(tile['dir'])
-        if len(cfg['images']) > 2:
-            for i in range(1, len(cfg['images'])):
-                common.mkdir_p(os.path.join(tile['dir'], 'pair_{}'.format(i)))
+        for i in range(1, len(cfg['images'])):
+            common.mkdir_p(os.path.join(tile['dir'], 'pair_{}'.format(i)))
 
         # save a json dump of the tile configuration
         tile_cfg = copy.deepcopy(cfg)


### PR DESCRIPTION
Write the list of config.json for all tiles, and avoid to strip pair_1 when there are only two images.