### PR TITLE
Make it compile when libs are in nonstandard location

### DIFF
--- a/c/homography/Makefile
+++ b/c/homography/Makefile
@@ -1,6 +1,6 @@
 CXXFLAGS ?= -march=native -O3
-override CXXFLAGS := $(CXXFLAGS) `gdal-config --cflags`
-override CXXLIBS  := $(CXXLIBS) `gdal-config --libs`
+override CXXFLAGS := $(CXXFLAGS) `gdal-config --cflags` `pkg-config --cflags fftw3`
+override CXXLIBS  := $(CXXLIBS) `gdal-config --libs` `pkg-config --libs fftw3` `pkg-config --libs fftw3f`
 
 OBJ = main.o \
       LibImages/LibImages.o \

--- a/makefile
+++ b/makefile
@@ -1,12 +1,12 @@
 # the following two options are used to control all C and C++ compilations
-export CFLAGS =   -march=native -O3
+export CFLAGS =   -march=native -O3 `gdal-config --cflags` `pkg-config --cflags fftw3`
 export CXXFLAGS = -march=native -O3
 
 # these options are only used for the programs directly inside "./c/"
 LDLIBS = -lstdc++
-IIOLIBS = -lz -ltiff -lpng -ljpeg -lm
+IIOLIBS = `gdal-config --libs` -lz -ltiff -lpng -ljpeg -lm
 GEOLIBS = -lgeotiff -ltiff
-FFTLIBS = -lfftw3f -lfftw3
+FFTLIBS = `pkg-config --libs fftw3` `pkg-config --libs fftw3f`
 
 # The following conditional statement appends "-std=gnu99" to CFLAGS when the
 # compiler does not define __STDC_VERSION__.  The idea is that many older


### PR DESCRIPTION
I made it explicit in c/homography/Makefile that depends on fftw3 to make it compile for me.

In the main makefile, make things compile if fftw, gdal, and other libraries are not in the standard location.
