### PR TITLE
homography: remove unneeded dependency on fft

### DIFF
--- a/c/homography/LibImages/LibImages.cpp
+++ b/c/homography/LibImages/LibImages.cpp
@@ -8,7 +8,6 @@
 //! Global includes
 #include <limits.h>
 #include <inttypes.h>
-#include <fftw3.h>
 #include <gdal_priv.h>
 #include <iostream>
 #include <fstream>


### PR DESCRIPTION
OK, I deleted my previous pull request. This one takes care of the core problem. 

Remove <fftw3.h> from homography, unnecessary. 