### PR TITLE
Fix broken msmw3 compilation with clang

### DIFF
--- a/c/msmw/CMakeLists.txt
+++ b/c/msmw/CMakeLists.txt
@@ -13,12 +13,13 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
         set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wa,-q")
         set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wa,-q")
     endif ()
-    # Optimize to the current CPU and enable warnings
-    #set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -march=native")
-    #set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -march=native")
-    set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -mavx")
-    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -mavx")
 endif ()
+
+# Optimize to the current CPU and enable warnings
+#set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -march=native")
+#set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -march=native")
+set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -mavx")
+set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -mavx")
 
 # Enable C99
 if (CMAKE_VERSION VERSION_LESS "3.1")

--- a/c/msmw/LibImages/LibImages.cpp
+++ b/c/msmw/LibImages/LibImages.cpp
@@ -805,14 +805,14 @@ void Image::convolveGaussian(
         //! Unroll the loops
         int k = 0;
         while (k + 4 < kSize) {
-          value += kernel[k + 0] * _mm_loadu_ps(line + j + k + 0) +
-                   kernel[k + 1] * _mm_loadu_ps(line + j + k + 1) +
-                   kernel[k + 2] * _mm_loadu_ps(line + j + k + 2) +
-                   kernel[k + 3] * _mm_loadu_ps(line + j + k + 3);
+          value += _mm_set1_ps(kernel[k + 0]) * _mm_loadu_ps(line + j + k + 0) +
+                   _mm_set1_ps(kernel[k + 1]) * _mm_loadu_ps(line + j + k + 1) +
+                   _mm_set1_ps(kernel[k + 2]) * _mm_loadu_ps(line + j + k + 2) +
+                   _mm_set1_ps(kernel[k + 3]) * _mm_loadu_ps(line + j + k + 3);
           k += 4;
         }
         for (; k < kSize; k++) {
-          value += kernel[k] * _mm_loadu_ps(line + j + k);
+          value += _mm_set1_ps(kernel[k]) * _mm_loadu_ps(line + j + k);
         }
         _mm_storeu_ps(iI + j, value);
       }
@@ -858,12 +858,14 @@ void Image::convolveGaussian(
         //! Unroll the loop
         int k = 0;
         while (k + 4 < kSize) {
-          value += kernel[k] * xCol[i + k] + kernel[k + 1] * xCol[i + k + 1] +
-            kernel[k + 2] * xCol[i + k + 2] + kernel[k + 3] * xCol[i + k + 3];
+          value += _mm_set1_ps(kernel[k + 0]) * xCol[i + k + 0] +
+                   _mm_set1_ps(kernel[k + 1]) * xCol[i + k + 1] +
+                   _mm_set1_ps(kernel[k + 2]) * xCol[i + k + 2] +
+                   _mm_set1_ps(kernel[k + 3]) * xCol[i + k + 3];
           k += 4;
         }
         for (; k < kSize; k++) {
-          value += kernel[k] * xCol[i + k];
+          value += _mm_set1_ps(kernel[k]) * xCol[i + k];
         }
 
         xCol[i] = value;

--- a/c/msmw/LibMSMW/UtilitiesMSMW.cpp
+++ b/c/msmw/LibMSMW/UtilitiesMSMW.cpp
@@ -67,7 +67,7 @@ __m128 computePatchDistance4(
   }
 
   //! Return the normalized result
-  return dist / float(i_im1.channels());
+  return dist / _mm_set1_ps(float(i_im1.channels()));
 }
 
 


### PR DESCRIPTION
This modification fixes the clang error "cannot convert between vector values of different size" happening when compiling the msmw3 target.