### PR TITLE
Feature Lidarpreprocessor Option

### DIFF
--- a/s2p.py
+++ b/s2p.py
@@ -515,9 +515,12 @@ def main(config_file, steps=ALL_STEPS):
         common.print_elapsed_time()
 
     if 'lidar-preprocessor' in steps:
-        print('lidar preprocessor...')
-        lidar_preprocessor(tiles)
-        common.print_elapsed_time()
+        if cfg['run_lidar_preprocessor']:
+            print('lidar preprocessor...')
+            lidar_preprocessor(tiles)
+            common.print_elapsed_time()
+        else:
+            print("LidarPreprocessor explictly disabled in config.json")
 
     # cleanup
     common.garbage_cleanup()

--- a/s2p.py
+++ b/s2p.py
@@ -520,7 +520,7 @@ def main(config_file, steps=ALL_STEPS):
             lidar_preprocessor(tiles)
             common.print_elapsed_time()
         else:
-            print("LidarPreprocessor explictly disabled in config.json")
+            print("LidarPreprocessor explicitly disabled in config.json")
 
     # cleanup
     common.garbage_cleanup()

--- a/s2plib/config.py
+++ b/s2plib/config.py
@@ -116,3 +116,6 @@ cfg['ll_bbx'] = ("-inf", "inf", "-inf", "inf")
 
 # use srtm to generate a watermask
 cfg['use_srtm_for_water'] = False
+
+# If true, lidar preprocessor will be called if found in path
+cfg['run_lidar_preprocessor'] = False


### PR DESCRIPTION
Adds an option for the use of LidarPreprocessor. If option is set to False, LidarPreprocessor is never used (default value). If set to True, previous behaviour is applied (use LidarPreprocessor if found in path).