### PR TITLE
[testing] registered_tests is now an OrderedDict

### DIFF
--- a/s2p_test.py
+++ b/s2p_test.py
@@ -11,6 +11,7 @@ import argparse
 import os
 import shutil
 import multiprocessing
+import collections
 
 import s2p
 import s2plib
@@ -176,14 +177,14 @@ def end2end_cluster(config):
              
     
 ############### Registered tests #######################
-    
-registered_tests = { 'unit_image_keypoints' : (unit_image_keypoints,[]),
-                     'unit_matching' : (unit_matching,[]),
-                     'unit_matches_from_rpc' : (unit_matches_from_rpc,[]),
-                     'end2end_pair' : (end2end, ['testdata/input_pair/config.json','testdata/expected_output/pair/dsm.tif',0.025,1]),
-                     'end2end_triplet' : (end2end, ['testdata/input_triplet/config.json','testdata/expected_output/triplet/dsm.tif',0.05,2]),
-                     'end2end_cluster' : (end2end_cluster, ['testdata/input_triplet/config.json'])}
 
+registered_tests = [('unit_image_keypoints', (unit_image_keypoints,[])),
+                    ('unit_matching', (unit_matching,[])),
+                    ('unit_matches_from_rpc', (unit_matches_from_rpc,[])),
+                    ('end2end_pair', (end2end, ['testdata/input_pair/config.json','testdata/expected_output/pair/dsm.tif',0.025,1])),
+                    ('end2end_triplet', (end2end, ['testdata/input_triplet/config.json','testdata/expected_output/triplet/dsm.tif',0.05,2])),
+                    ('end2end_cluster', (end2end_cluster, ['testdata/input_triplet/config.json']))]
+registered_tests = collections.OrderedDict(registered_tests)
 
 
 ############### Tests main  #######################


### PR DESCRIPTION
jmichel-otb : "OrderedDict allows to get tests executed in the order they are registered. Otherwise execution order is random.
This can be useful since end2end_cluster actually needs the results from end2end_triplet. If s2p_test.py --all guarantees that end2end_triplet has been executed when running end2end_cluster, we can save testing time (use skip_existing=True when running it again for instance)."