### PR TITLE
[bug] iteritems() is not available in python3, and items() is ineficient in python2

### DIFF
--- a/s2p_test.py
+++ b/s2p_test.py
@@ -218,7 +218,7 @@ if __name__ == '__main__':
         parser.print_help()
         
         print(os.linesep+'available tests:')
-        for test,commands in registered_tests.iteritems():
+        for test in registered_tests:
             print('\t'+test)
         exit(1)
 


### PR DESCRIPTION
There is a iteritems() function in six library that works and is efficient in both python, but it would add a new dependency