### PR TITLE
[doc] further hacker guidelines

### DIFF
--- a/HACKERS
+++ b/HACKERS
@@ -26,11 +26,6 @@ helpful to refer to the philosophy points (P1)--(P7) outlined below.
 you cannot add a feature and change the testing system at the same time.  More
 importantly, you cannot refactor and bugfix.
 
-(E8) Pending reviews of each team are cleared before submitting new pull
-requests.  Thus the other team can continue working without worrying about
-merge conflicts.
-
-
 
 PHILOSOPHY
 

--- a/HACKERS
+++ b/HACKERS
@@ -22,9 +22,8 @@ helpful to refer to the philosophy points (P1)--(P7) outlined below.
 	* [doc] documentation / comments
 	* [trivial] typo or trivial bugfix on a single file
 
-(E7) The types of pull requests in (E6) are mutually exclusive.  For example,
-you cannot add a feature and change the testing system at the same time.  More
-importantly, you cannot refactor and bugfix.
+(E7) As far as possible, the types of pull requests in (E6) should be mutually exclusive.
+For example, you cannot refactor and bugfix.
 
 
 PHILOSOPHY

--- a/HACKERS
+++ b/HACKERS
@@ -13,6 +13,23 @@ persons must be different to the author of the pull request.
 (E5) Optional: If the intent of the pull request is not clear, it may be
 helpful to refer to the philosophy points (P1)--(P7) outlined below.
 
+(E6) Admissible types of pull requests:
+	* [bugfix] solves a concrete problem, changing one or at most two files
+	* [feature] adds a new feature which is disabled by default
+	* [config] changes the default configuration options
+	* [refactor] moves files/functions around without changing the algorithm
+	* [testing] changes the testing system, adds test data, etc.
+	* [doc] documentation / comments
+	* [trivial] typo or trivial bugfix on a single file
+
+(E7) The types of pull requests in (E6) are mutually exclusive.  For example,
+you cannot add a feature and change the testing system at the same time.  More
+importantly, you cannot refactor and bugfix.
+
+(E8) Pending reviews of each team are cleared before submitting new pull
+requests.  Thus the other team can continue working without worrying about
+merge conflicts.
+
 
 
 PHILOSOPHY


### PR DESCRIPTION
This is the same PR of last week, but taking into account the comments by Julien Michel.

Point (E6) lists the admissible types of PR.  It seems that everybody is OK with this list.

Point (E7) states that the different types of PR cannot be mixed.  The goal is that reviewing them is as easy as possible.  Since reviewing a new feature requires a very different mindset than reviewing a test, it is important to keep them separated (they should be easy to split in all cases).

I removed point (E8) because it was confusing.  The goal was exactly the opposite than the interpretation of JM; but in any case this is an organization detail of our teams that is not of general interest. (the goal was to reassure the people of Toulouse that the people of Cachan will review their PR before pushing new features).