### PR TITLE
[bugfix] cleared s2plib.config.cfg

### DIFF
--- a/s2p_test.py
+++ b/s2p_test.py
@@ -282,6 +282,7 @@ if __name__ == '__main__':
             command,args = registered_tests[test]
             try:
                 # Ensure each test starts from the default cfg
+                s2plib.config.cfg.clear()
                 s2plib.config.cfg.update(test_default_cfg)
                 command(*args)
                 print('Success.'+os.linesep)


### PR DESCRIPTION
to ensure each test starts from the default cfg