### PR TITLE
[bugfix] MacOS Travis plateform seems to already contain a libgeotiff version 1.4.1_2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-add-repository -y ppa:ubuntugis/ppa; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get -qq update; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install gdal-bin libfftw3-dev libgdal-dev libgeotiff-dev geographiclib-tools libgeographiclib-dev; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install geographiclib fftw libgeotiff; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew unlink libgeotiff; brew install geographiclib fftw libgeotiff; fi
 
 install:
   - pip install numpy utm bs4 requests


### PR DESCRIPTION

The script now unlinks the libgeotiff before installing it
Assuming Travis does not change its MacOS conf we could actually plan no to brew install libgeotiff anymore...