### PR TITLE
[bugfix] fix 'import s2p' issue in utils modules

### DIFF
--- a/s2p.py
+++ b/s2p.py
@@ -798,12 +798,6 @@ def main(user_cfg, steps=ALL_STEPS):
     common.print_elapsed_time(since_first_call=True)
 
 
-def make_path_relative_to_json_file(path,json_file):
-    json_abs_path = os.path.abspath(os.path.dirname(json_file))
-    out_path = os.path.join(json_abs_path,path)
-    return out_path
-
-
 def read_tiles(tiles_file):
     tiles = []
     outdir = os.path.dirname(tiles_file)
@@ -818,27 +812,6 @@ def read_tiles(tiles_file):
     return tiles
 
 
-def read_config_file(config_file):
-    # read the json configuration file
-    with open(config_file, 'r') as f:
-        user_cfg = json.load(f)
-
-    # Check if out_dir is a relative path
-    # In this case the relative path is relative to the config.json location,
-    # and not to the cwd
-    if not os.path.isabs(user_cfg['out_dir']):
-        print('WARNING: Output directory is a relative path, it will be interpreted with respect to config.json location, and not cwd')
-        user_cfg['out_dir'] = make_path_relative_to_json_file(user_cfg['out_dir'],config_file)
-        print('Output directory will be: '+user_cfg['out_dir'])
-
-    for i in range(0,len(user_cfg['images'])):
-        for d in ['clr','cld','roi','wat','img','rpc']:
-            if d in user_cfg['images'][i] and user_cfg['images'][i][d] is not None and not os.path.isabs(user_cfg['images'][i][d]):
-                user_cfg['images'][i][d]=make_path_relative_to_json_file(user_cfg['images'][i][d],config_file)
-        
-    return user_cfg
-
-
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description=('S2P: Satellite Stereo '
                                                   'Pipeline'))
@@ -850,7 +823,7 @@ if __name__ == '__main__':
                         default=ALL_STEPS)
     args = parser.parse_args()
 
-    user_cfg = read_config_file(args.config)
+    user_cfg = initialization.read_config_file(args.config)
 
     main(user_cfg, args.step)
 

--- a/s2p_test.py
+++ b/s2p_test.py
@@ -118,7 +118,7 @@ def unit_distributed_plyflatten(config):
 
     print('Running end2end with distributed plyflatten dsm ...')
 
-    test_cfg = s2p.read_config_file(config)
+    test_cfg = s2plib.initialization.read_config_file(config)
     test_cfg['skip_existing'] = True
     s2p.main(test_cfg)
 
@@ -177,7 +177,7 @@ def end2end(config,ref_dsm,absmean_tol=0.025,percentile_tol=1.):
     print('Configuration file: ',config)
     print('Reference DSM:',ref_dsm,os.linesep)
     
-    test_cfg = s2p.read_config_file(config)
+    test_cfg = s2plib.initialization.read_config_file(config)
     s2p.main(test_cfg)
 
     outdir = test_cfg['out_dir']
@@ -192,7 +192,7 @@ def end2end_cluster(config):
 
     print('Running end2end in sequential mode to get reference DSM ...')
 
-    test_cfg = s2p.read_config_file(config)
+    test_cfg = s2plib.initialization.read_config_file(config)
     test_cfg['skip_existing'] = True
     s2p.main(test_cfg)
     
@@ -220,7 +220,7 @@ def end2end_cluster(config):
             print('Running %s on each tile...' % step)
             for tile in tiles:
                 print('tile : %s' % tile)
-                tile_cfg_cluster = s2p.read_config_file(tile)
+                tile_cfg_cluster = s2plib.initialization.read_config_file(tile)
                 s2p.main(tile_cfg_cluster, [step])
         else:
             print('Running %s...' % step)
@@ -233,7 +233,7 @@ def end2end_cluster(config):
   
 def end2end_mosaic(config,ref_height_map,absmean_tol=0.025,percentile_tol=1.):
 
-    test_cfg = s2p.read_config_file(config)
+    test_cfg = s2plib.initialization.read_config_file(config)
     outdir = test_cfg['out_dir']
     test_cfg['skip_existing'] = True
     s2p.main(test_cfg)

--- a/s2plib/initialization.py
+++ b/s2plib/initialization.py
@@ -303,3 +303,35 @@ def tiles_full_info(tw, th):
                    tile['mask'].astype(np.uint8))
 
     return tiles
+
+
+def make_path_relative_to_file(path, f):
+    return os.path.join(os.path.abspath(os.path.dirname(f)), path)
+
+
+def read_config_file(config_file):
+    """
+    Read a json configuration file and interpret relative paths.
+
+    If any input or output path is a relative path, it is interpreted as
+    relative to the config_file location (and not relative to the current
+    working directory). Absolute paths are left unchanged.
+    """
+    with open(config_file, 'r') as f:
+        user_cfg = json.load(f)
+
+    # output paths
+    if not os.path.isabs(user_cfg['out_dir']):
+        print('WARNING: out_dir is a relative path. It is interpreted with '
+              'respect to {} location (not cwd)'.format(config_file))
+        user_cfg['out_dir'] = make_path_relative_to_file(user_cfg['out_dir'],
+                                                         config_file)
+        print('out_dir is: {}'.format(user_cfg['out_dir']))
+
+    # input paths
+    for img in user_cfg['images']:
+        for d in ['img', 'rpc', 'clr', 'cld', 'roi', 'wat']:
+            if d in img and img[d] is not None and not os.path.isabs(img[d]):
+                img[d] = make_path_relative_to_file(img[d], config_file)
+
+    return user_cfg

--- a/utils/kml_tilemap.py
+++ b/utils/kml_tilemap.py
@@ -25,9 +25,10 @@ import collections
 import utm
 import simplekml
 import gdal
-
 import numpy as np
-import s2p
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from s2plib import initialization
 from s2plib import rpc_model
 from s2plib import common
 
@@ -96,7 +97,7 @@ def get_coordinates_with_img(img):
     return [pix_2_latlon(gt, x[0], x[1], zone_number, northern) for x in roi]
 
 def get_coordinates_with_config(tile, m, M):
-    tile_cfg = s2p.read_config_file(os.path.join(tile, "config.json"))
+    tile_cfg = initialization.read_config_file(os.path.join(tile, "config.json"))
 
     x = tile_cfg['roi']['x']
     y = tile_cfg['roi']['y']
@@ -181,7 +182,7 @@ def write_tiles_polygon(tile, kml, m=None, M=None, message=None, error_mode=Fals
         color = simplekml.Color.green
         head_style = green_style
 
-    tile_cfg = s2p.read_config_file(os.path.join(tile, "config.json"))
+    tile_cfg = initialization.read_config_file(os.path.join(tile, "config.json"))
     x = tile_cfg['roi']['x']
     y = tile_cfg['roi']['y']
     w = tile_cfg['roi']['w']

--- a/utils/svg_tilemap.py
+++ b/utils/svg_tilemap.py
@@ -24,7 +24,7 @@ import numpy as np
 import datetime
 
 
-import s2p
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from s2plib.config import cfg
 from s2plib import common
 from s2plib import initialization
@@ -100,6 +100,6 @@ if __name__ == '__main__':
                               'parameters'))
     args = parser.parse_args()
 
-    user_cfg = s2p.read_config_file(args.config)
+    user_cfg = initialization.read_config_file(args.config)
 
     main(user_cfg)


### PR DESCRIPTION
The current version of `utils/svg_tilemap.py` is broken because of `import s2p`. This modification fixes the issue by moving the `read_config_file` function into the `s2plib/initialization.py` module.