### PR TITLE
[refactor] refactor disparity range method

### DIFF
--- a/s2plib/config.py
+++ b/s2plib/config.py
@@ -90,9 +90,14 @@ cfg['matching_algorithm'] = 'mgm'
 # size of the Census NCC square windows used in mgm
 cfg['census_ncc_win'] = 5
 
-# set these params if you want to impose the disparity range manually
+# set these params if you want to impose the disparity range manually (cfg['disp_range_method'] == 'fixed_pixel_range')
 cfg['disp_min'] = None
 cfg['disp_max'] = None
+
+# set these params if you want to impose the altitude range manually (cfg['disp_range_method'] == 'fixed_altitude_range')
+cfg['alt_min'] = None
+cfg['alt_max'] = None
+
 
 # radius for erosion of valid disparity areas. Ignored if less than 2
 cfg['msk_erosion'] = 2
@@ -106,7 +111,7 @@ cfg['fusion_thresh'] = 3
 cfg['disable_srtm'] = False
 cfg['rpc_alt_range_scale_factor'] = 1
 
-# method to compute the disparity range: "sift", "srtm" or "wider_sift_srtm"
+# method to compute the disparity range: "sift", "srtm", "wider_sift_srtm", "fixed_pixel_range", "fixed_altitude_range"
 cfg['disp_range_method'] = "wider_sift_srtm"
 cfg['disp_range_srtm_low_margin'] = -10
 cfg['disp_range_srtm_high_margin'] = +100

--- a/s2plib/rpc_utils.py
+++ b/s2plib/rpc_utils.py
@@ -593,17 +593,43 @@ def srtm_disp_range_estimation(rpc1, rpc2, x, y, w, h, H1, H2, A=None,
     """
     m, M = altitude_range(rpc1, x, y, w, h, margin_top, margin_bottom)
 
+    return altitude_range_to_disp_range(m,M,rpc1, rpc2, x, y, w, h, H1, H2, A,
+                                        margin_top, margin_bottom)
+
+def altitude_range_to_disp_range(m,M,rpc1, rpc2, x, y, w, h, H1, H2, A=None,
+                                margin_top=0, margin_bottom=0):
+    """
+    Args:
+        m: Min altitude over the tile
+        M: Max altitude over the tile
+        rpc1: an instance of the rpc_model.RPCModel class for the reference
+            image
+        rpc2: an instance of the rpc_model.RPCModel class for the secondary
+            image
+        x, y, w, h: four integers defining a rectangular region of interest
+            (ROI) in the reference image. (x, y) is the top-left corner, and
+            (w, h) are the dimensions of the rectangle.
+        H1, H2: rectifying homographies
+        A (optional): pointing correction matrix
+        margin_top: margin (in meters) to add to the upper bound of the range
+        margin_bottom: margin (negative) to add to the lower bound of the range
+
+    Returns:
+        the min and max horizontal disparity observed on the 4 corners of the
+        ROI with the min/max altitude assumptions given as parameters. The
+        disparity is made horizontal thanks to the two rectifying homographies
+        H1 and H2.
+    """
     # build an array with vertices of the 3D ROI, obtained as {2D ROI} x [m, M]
     a = np.array([x, x,   x,   x, x+w, x+w, x+w, x+w])
     b = np.array([y, y, y+h, y+h,   y,   y, y+h, y+h])
     c = np.array([m, M,   m,   M,   m,   M,   m,   M])
-
+    
     # compute the disparities of these 8 points
     d = alt_to_disp(rpc1, rpc2, a, b, c, H1, H2, A)
-
+    
     # return min and max disparities
     return np.min(d), np.max(d)
-
 
 def compute_ms_panchro_offset(dim_pan, dim_ms):
     """


### PR DESCRIPTION
This PR refactors the way disparity range is computed, so that everything happens within the disparity_range() function.

It also provides new disparity range estimation modes:
- fixed_pixel_range (was previously implicitly enabled by disp_min and disp_max parameters, that were overriding disparity)
- fixed_altitude_range (in meters)

For the latter, a refactoring was needed in rpc_utils to reuse a function that computes the disparity range over SRTM.

Also note that this condition disappeared:

if cfg['disp_range_method'] == 'srtm' or matches is None or len(matches) < 2:

Default disparity if everything else breaks is [-3,3]. If you are in sift disparity range mode and found no SIFT matches, you will fall back to [-3,3] instead of implicitly switching to srtm mode.
