### PR TITLE
[refactor] remove all code related to subsampling_factor parameter

### DIFF
--- a/s2p.py
+++ b/s2p.py
@@ -260,7 +260,7 @@ def disparity_to_height(tile, i):
     out_mask = os.path.join(tile['dir'], 'cloud_water_image_domain_mask.png')
     pointing = os.path.join(cfg['out_dir'],
                             'global_pointing_pair_{}.txt'.format(i))
-    triangulation.height_map(height_map, x, y, w, h, cfg['subsampling_factor'],
+    triangulation.height_map(height_map, x, y, w, h,
                              rpc1, rpc2, H_ref, H_sec, disp, mask, rpc_err,
                              out_mask, pointing)
 
@@ -444,9 +444,8 @@ def mean_heights(tile):
     """
     """
     w, h = tile['coordinates'][2:]
-    z = cfg['subsampling_factor']
     n = len(cfg['images']) - 1
-    maps = np.empty((int(h/z), int(w/z), n))
+    maps = np.empty((h, w, n))
     for i in range(n):
         try:
             f = gdal.Open(os.path.join(tile['dir'], 'pair_{}'.format(i + 1),
@@ -522,7 +521,6 @@ def heights_to_ply(tile):
     # compute a ply from the merged height map
     out_dir = tile['dir']
     x, y, w, h = tile['coordinates']
-    z = cfg['subsampling_factor']
     plyfile = os.path.join(out_dir, 'cloud.ply')
     plyextrema = os.path.join(out_dir, 'plyextrema.txt')
     height_map = os.path.join(out_dir, 'height_map.tif')
@@ -532,14 +530,14 @@ def heights_to_ply(tile):
 
     # H is the homography transforming the coordinates system of the original
     # full size image into the coordinates system of the crop
-    H = np.dot(np.diag([1 / z, 1 / z, 1]), common.matrix_translation(-x, -y))
+    H = np.dot(np.diag([1, 1, 1]), common.matrix_translation(-x, -y))
     colors = os.path.join(out_dir, 'ref.png')
     if cfg['images'][0]['clr']:
         common.image_crop_gdal(cfg['images'][0]['clr'], x, y, w, h, colors)
     else:
         common.image_qauto(common.image_crop_gdal(cfg['images'][0]['img'], x, y,
                                                  w, h), colors)
-    common.image_safe_zoom_fft(colors, z, colors)
+        
     triangulation.height_map_to_point_cloud(plyfile, height_map,
                                             cfg['images'][0]['rpc'], H, colors,
                                             utm_zone=cfg['utm_zone'],

--- a/s2plib/common.py
+++ b/s2plib/common.py
@@ -771,26 +771,6 @@ def download(to_file, from_url):
                 print(status, end=" ")
 
 
-def round_roi_to_nearest_multiple(n, x, y, w, h):
-    """
-    Rounds coordinates of a ROI to the nearest multiple of a given int.
-
-    Args:
-        n: integer
-        x, y, w, h: 4 numbers defining a ROI
-
-    Returns:
-        x, y, w, h: 4 ints close to the input numbers. x and y are rounded
-            down, while w and h are rounded up to the nearest multiple of n.
-    """
-    x, y, w, h = map(float, [x, y, w, h])
-    x = n * np.floor(x / n)
-    y = n * np.floor(y / n)
-    w = n * np.ceil(w / n)
-    h = n * np.ceil(h / n)
-    return map(int, [x, y, w, h])
-
-
 def lidar_preprocessor(output, input_plys):
     """
     Compute a multi-scale representation of a large point cloud.

--- a/s2plib/config.py
+++ b/s2plib/config.py
@@ -59,9 +59,6 @@ cfg['dsm_radius'] = 0
 # (dsm_resolution by default)
 cfg['dsm_sigma'] = None
 
-# zoom out applied to input images
-cfg['subsampling_factor'] = 1
-
 # sift threshold on the first over second best match ratio
 cfg['sift_match_thresh'] = 0.6
 

--- a/s2plib/initialization.py
+++ b/s2plib/initialization.py
@@ -76,6 +76,12 @@ def check_parameters(d):
         print('ERROR: missing or incomplete roi definition')
         sys.exit(1)
 
+    # d['roi'] : all the values must be integers
+    d['roi']['x'] = int(np.floor(d['roi']['x']))
+    d['roi']['y'] = int(np.floor(d['roi']['y']))
+    d['roi']['w'] = int(np.ceil(d['roi']['w']))
+    d['roi']['h'] = int(np.ceil(d['roi']['h']))
+
     # warn about unknown parameters. The known parameters are those defined in
     # the global config.cfg dictionary, plus the mandatory 'images' and 'roi' or
     # 'roi_utm'

--- a/s2plib/masking.py
+++ b/s2plib/masking.py
@@ -31,12 +31,11 @@ def cloud_water_image_domain(x, y, w, h, rpc, roi_gml=None, cld_gml=None,
         2D array containing the output binary mask. 0 indicate masked pixels, 1
         visible pixels.
     """
-    # coefficients of the transformation associated to the crop and zoom
-    z = cfg['subsampling_factor']
-    H = np.dot(np.diag((1/z, 1/z, 1)), common.matrix_translation(-x, -y))
+    # coefficients of the transformation associated to the crop
+    H = np.dot(np.diag((1, 1, 1)), common.matrix_translation(-x, -y))
     hij = ' '.join([str(el) for el in H.flatten()])
 
-    w, h = int(w/z), int(h/z)
+    
     mask = np.ones((h, w), dtype=np.bool)
 
     if roi_gml is not None:  # image domain mask (polygons)

--- a/s2plib/masking.py
+++ b/s2plib/masking.py
@@ -32,9 +32,8 @@ def cloud_water_image_domain(x, y, w, h, rpc, roi_gml=None, cld_gml=None,
         visible pixels.
     """
     # coefficients of the transformation associated to the crop
-    H = np.dot(np.diag((1, 1, 1)), common.matrix_translation(-x, -y))
+    H = common.matrix_translation(-x, -y)
     hij = ' '.join([str(el) for el in H.flatten()])
-
     
     mask = np.ones((h, w), dtype=np.bool)
 

--- a/s2plib/rectification.py
+++ b/s2plib/rectification.py
@@ -309,13 +309,6 @@ def rectify_pair(im1, im2, rpc1, rpc2, x, y, w, h, out1, out2, A=None,
         {h,v}margin (optional): horizontal and vertical margins added on the
             sides of the rectified images
 
-        This function uses the parameter subsampling_factor from the
-        config module. If the factor z > 1 then the output images will
-        be subsampled by a factor z. The output matrices H1, H2, and the
-        ranges are also updated accordingly:
-        Hi = Z * Hi with Z = diag(1/z, 1/z, 1) and
-        disp_min = disp_min / z  (resp _max)
-
     Returns:
         H1, H2: Two 3x3 matrices representing the rectifying homographies that
         have been applied to the two original (large) images.
@@ -383,17 +376,6 @@ def rectify_pair(im1, im2, rpc1, rpc2, x, y, w, h, out1, out2, A=None,
         T = common.matrix_translation(-x + hmargin, -y + vmargin)
         H1 = np.dot(T, H1)
         H2 = np.dot(T, H2)
-
-    #  if subsampling_factor'] the homographies are altered to reflect the zoom
-    z = cfg['subsampling_factor']
-    if z != 1:
-        Z = np.diag((1/z, 1/z, 1))
-        H1 = np.dot(Z, H1)
-        H2 = np.dot(Z, H2)
-        disp_m = np.floor(disp_m / z)
-        disp_M = np.ceil(disp_M / z)
-        hmargin = int(np.floor(hmargin / z))
-        vmargin = int(np.floor(vmargin / z))
 
     # compute output images size
     roi = [[x, y], [x+w, y], [x+w, y+h], [x, y+h]]

--- a/s2plib/triangulation.py
+++ b/s2plib/triangulation.py
@@ -46,15 +46,13 @@ def transfer_map(in_map, H, x, y, w, h, out_map):
         x, y, w, h: four integers defining the rectangular ROI in the original
             image. (x, y) is the top-left corner, and (w, h) are the dimensions
             of the rectangle.
-        zoom: zoom factor (usually 1, 2 or 4) used to produce the input height
-            map
         out_map: path to the output map
     """
     # write the inverse of the resampling transform matrix. In brief it is:
-    # homography * translation * zoom
+    # homography * translation
     # This matrix transports the coordinates of the original cropped and
-    # zoomed grid (the one desired for out_height) to the rectified cropped and
-    # zoomed grid (the one we have for height)
+    # grid (the one desired for out_height) to the rectified cropped and
+    # grid (the one we have for height)
     Z = np.diag([1, 1, 1])
     A = common.matrix_translation(x, y)
     HH = np.dot(np.loadtxt(H), np.dot(A, Z))
@@ -65,7 +63,7 @@ def transfer_map(in_map, H, x, y, w, h, out_map):
     # zero:256x256 is the iio way to create a 256x256 image filled with zeros
     hij = ' '.join(['%r' % num for num in HH.flatten()])
     common.run('synflow hom "%s" zero:%dx%d /dev/null - | BILINEAR=1 backflow - %s %s' % (
-        hij, w/zoom, h/zoom, in_map, out_map))
+        hij, w, h, in_map, out_map))
 
     # replace the -inf with nan in the heights map, because colormesh filter
     # out nans but not infs

--- a/s2plib/triangulation.py
+++ b/s2plib/triangulation.py
@@ -53,9 +53,7 @@ def transfer_map(in_map, H, x, y, w, h, out_map):
     # This matrix transports the coordinates of the original cropped and
     # grid (the one desired for out_height) to the rectified cropped and
     # grid (the one we have for height)
-    Z = np.diag([1, 1, 1])
-    A = common.matrix_translation(x, y)
-    HH = np.dot(np.loadtxt(H), np.dot(A, Z))
+    HH = np.dot(np.loadtxt(H), common.matrix_translation(x, y))
 
     # apply the homography
     # write the 9 coefficients of the homography to a string, then call synflow

--- a/s2plib/triangulation.py
+++ b/s2plib/triangulation.py
@@ -33,7 +33,7 @@ def height_map_rectified(rpc1, rpc2, H1, H2, disp, mask, height, rpc_err, A=None
                                                       mask, height, rpc_err))
 
 
-def transfer_map(in_map, H, x, y, w, h, zoom, out_map):
+def transfer_map(in_map, H, x, y, w, h, out_map):
     """
     Transfer the heights computed on the rectified grid to the original
     Pleiades image grid.
@@ -55,7 +55,7 @@ def transfer_map(in_map, H, x, y, w, h, zoom, out_map):
     # This matrix transports the coordinates of the original cropped and
     # zoomed grid (the one desired for out_height) to the rectified cropped and
     # zoomed grid (the one we have for height)
-    Z = np.diag([zoom, zoom, 1])
+    Z = np.diag([1, 1, 1])
     A = common.matrix_translation(x, y)
     HH = np.dot(np.loadtxt(H), np.dot(A, Z))
 
@@ -73,7 +73,7 @@ def transfer_map(in_map, H, x, y, w, h, zoom, out_map):
     # common.run('plambda %s "x isinf nan x if" > %s' % (tmp_h, out_height))
 
 
-def height_map(out, x, y, w, h, z, rpc1, rpc2, H1, H2, disp, mask, rpc_err,
+def height_map(out, x, y, w, h, rpc1, rpc2, H1, H2, disp, mask, rpc_err,
                out_filt, A=None):
     """
     Computes an altitude map, on the grid of the original reference image, from
@@ -84,8 +84,6 @@ def height_map(out, x, y, w, h, z, rpc1, rpc2, H1, H2, disp, mask, rpc_err,
         x, y, w, h: four integers defining the rectangular ROI in the original
             image. (x, y) is the top-left corner, and (w, h) are the dimensions
             of the rectangle.
-        z: zoom factor (usually 1, 2 or 4) used to produce the input disparity
-            map
         rpc1, rpc2: paths to the xml files
         H1, H2: path to txt files containing two 3x3 numpy arrays defining
             the rectifying homographies
@@ -96,7 +94,7 @@ def height_map(out, x, y, w, h, z, rpc1, rpc2, H1, H2, disp, mask, rpc_err,
     """
     tmp = common.tmpfile('.tif')
     height_map_rectified(rpc1, rpc2, H1, H2, disp, mask, tmp, rpc_err, A)
-    transfer_map(tmp, H1, x, y, w, h, z, out)
+    transfer_map(tmp, H1, x, y, w, h, out)
 
     # apply output filter
     common.run('plambda {0} {1} "x 0 > y nan if" -o {1}'.format(out_filt, out))

--- a/testdata/input_pair/config.json
+++ b/testdata/input_pair/config.json
@@ -16,7 +16,6 @@
   "matching_algorithm" : "mgm",
   "horizontal_margin": 20,
   "vertical_margin": 5,
-  "subsampling_factor" : 1,
   "sift_match_thresh" : 0.6,
   "disp_range_extra_margin" : 0.2,
   "n_gcp_per_axis" : 5,

--- a/testdata/input_triplet/config.json
+++ b/testdata/input_triplet/config.json
@@ -18,7 +18,6 @@
   "matching_algorithm" : "mgm",
   "horizontal_margin": 20,
   "vertical_margin": 5,
-  "subsampling_factor" : 1,
   "sift_match_thresh" : 0.6,
   "disp_range_extra_margin" : 0.2,
   "n_gcp_per_axis" : 5,

--- a/testdata/input_triplet/config_geo.json
+++ b/testdata/input_triplet/config_geo.json
@@ -18,7 +18,6 @@
   "matching_algorithm" : "mgm",
   "horizontal_margin": 20,
   "vertical_margin": 5,
-  "subsampling_factor" : 1,
   "sift_match_thresh" : 0.6,
   "disp_range_extra_margin" : 0.2,
   "n_gcp_per_axis" : 5,


### PR DESCRIPTION
This parameter never worked quite properly, and the code is simpler without it. If someone wants to make a low resolution DSM, she could always scale RPC and images beforehand, with the tool provided in PR #129.

Also note that the last patch was needed because of a nasty python bug that was previously masked by the tile size rounding code.