### PR TITLE
Add test and instruction for gdal version

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ In json configuration files, relative file path for inputs files and output dire
 
 Required dependencies (Ubuntu 16.04):
 
+    sudo add-apt-repository ppa:ubuntugis/ppa  && sudo apt-get update # The repository is added so that the version >= 2.1 of gdal is installed (requirement)
     apt-get install build-essential cmake gdal-bin geographiclib-tools libgeographic-dev libfftw3-dev libgdal-dev libgeotiff-dev libtiff5-dev python python-gdal python-numpy python-pip
 
 and

--- a/README.md
+++ b/README.md
@@ -101,6 +101,9 @@ All the sources (ours and 3rdparties) are compiled from the same makefile. Just
 run `make all` from the `s2p` folder to compile them.  This will create a `bin`
 directory containing all the needed binaries.
 
+You can test if S2P is correctly working using:
+
+    make test
 
 ### MicMac (optional)
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ In json configuration files, relative file path for inputs files and output dire
 
 Required dependencies (Ubuntu 16.04):
 
-    sudo add-apt-repository ppa:ubuntugis/ppa  && sudo apt-get update # The repository is added so that the version >= 2.1 of gdal is installed (requirement)
+    add-apt-repository -y ppa:ubuntugis/ubuntugis-unstable # The repository is added so that the version >= 2.1 of gdal is installed (requirement)
+    apt-get update
     apt-get install build-essential cmake gdal-bin geographiclib-tools libgeographic-dev libfftw3-dev libgdal-dev libgeotiff-dev libtiff5-dev python python-gdal python-numpy python-pip
 
 and

--- a/s2p_test.py
+++ b/s2p_test.py
@@ -22,6 +22,16 @@ import s2plib
 
 ############### Tests functions  #######################
 
+def unit_gdal_version():
+    try:
+        import gdal
+        version_num = int(gdal.VersionInfo('VERSION_NUM'))
+        if (version_num < 2010000):
+            raise AssertionError("The version of GDAL should be at least 2.1.\nHere is the recommended fix if installed on Ubuntu 16.04:\nsudo add-apt-repository ppa:ubuntugis/ppa && sudo apt-get update\nsudo apt-get install gdal-bin")
+    except ImportError:
+        raise AssertionError('GDAL does not seem to be installed.')
+
+
 def unit_image_keypoints():
 
     kpts = s2plib.sift.image_keypoints('testdata/input_triplet/img_02.tif',100,100,200,200)
@@ -251,7 +261,8 @@ def end2end_mosaic(config,ref_height_map,absmean_tol=0.025,percentile_tol=1.):
     
 ############### Registered tests #######################
 
-registered_tests = [('unit_image_keypoints', (unit_image_keypoints,[])),
+registered_tests = [('unit_gdal_version', (unit_gdal_version,[])),
+                    ('unit_image_keypoints', (unit_image_keypoints,[])),
                     ('unit_matching', (unit_matching,[])),
                     ('unit_plyflatten', (unit_plyflatten,[])),
                     ('unit_matches_from_rpc', (unit_matches_from_rpc,[])),

--- a/s2p_test.py
+++ b/s2p_test.py
@@ -27,7 +27,7 @@ def unit_gdal_version():
         import gdal
         version_num = int(gdal.VersionInfo('VERSION_NUM'))
         if (version_num < 2010000):
-            raise AssertionError("The version of GDAL should be at least 2.1.\nHere is the recommended fix if installed on Ubuntu 16.04:\nsudo add-apt-repository ppa:ubuntugis/ppa && sudo apt-get update\nsudo apt-get install gdal-bin")
+            raise AssertionError("The version of GDAL should be at least 2.1.\nHere is the recommended fix if installed on Ubuntu 16.04:\nadd-apt-repository -y ppa:ubuntugis/ubuntugis-unstable\nsudo apt-get update\nsudo apt-get upgrade")
     except ImportError:
         raise AssertionError('GDAL does not seem to be installed.')
 


### PR DESCRIPTION
Hi!

I am a new user of S2P and I encountered problems when using S2P in Ubuntu 16.04 as it installs the version 1 of GDAL by default. I have been shown the fix, so it is correctly working now. Here are some suggestions of changes in the tests and the README file so that new users like me don't encounter this issue anymore.

Thanks,