### PR TITLE
Update rpc_utils.py

### DIFF
--- a/s2plib/rpc_utils.py
+++ b/s2plib/rpc_utils.py
@@ -238,7 +238,7 @@ def min_max_heights_from_bbx(im, lon_m, lon_M, lat_m, lat_M, rpc):
     lonlatalt = zip(np.ravel(lonv),
                     np.ravel(latv),
                     np.zeros(np.shape(np.ravel(lonv))))
-    x_im_proj, y_im_proj, __ = (zip(*lonlat_to_im.TransformPoints(lonlatalt)))
+    x_im_proj, y_im_proj, __ = (zip(*lonlat_to_im.TransformPoints([a for a in lonlatalt])))
     x_im_proj = np.array(x_im_proj)
     y_im_proj = np.array(y_im_proj)
 


### PR DESCRIPTION
When using exogenous_dem option - the function min_max_heights_from_bbx calls

x_im_proj, y_im_proj, __ = (zip(*lonlat_to_im.TransformPoints(lonlatalt)))
however lonlatalt is not a sequence as TransformPoints is expecting.

Instead changed to:
x_im_proj, y_im_proj, __ = (zip(*lonlat_to_im.TransformPoints([a for a in lonlatalt])))