### PR TITLE
[feature] avoid changing parameters otf for nb_workers and omp_num_threads

### DIFF
--- a/s2p.py
+++ b/s2p.py
@@ -669,9 +669,8 @@ def main(user_cfg, steps=ALL_STEPS):
 
     # multiprocessing setup
     nb_workers = multiprocessing.cpu_count()  # nb of available cores
-    if cfg['max_processes']:
-        nb_workers = min(nb_workers, cfg['max_processes'])
-    cfg['max_processes'] = nb_workers
+    if cfg['max_processes'] is not None:
+        nb_workers = cfg['max_processes']
 
     tw, th = initialization.adjust_tile_size()
     tiles_txt = os.path.join(cfg['out_dir'],'tiles.txt')
@@ -686,9 +685,6 @@ def main(user_cfg, steps=ALL_STEPS):
 
     n = len(cfg['images'])
     tiles_pairs = [(t, i) for i in range(1, n) for t in tiles]
-
-    # omp_num_threads should not exceed nb_workers when multiplied by len(tiles)
-    cfg['omp_num_threads'] = max(1, int(nb_workers / len(tiles_pairs)))
 
     if 'local-pointing' in steps:
         print('correcting pointing locally...')

--- a/s2plib/initialization.py
+++ b/s2plib/initialization.py
@@ -291,7 +291,6 @@ def tiles_full_info(tw, th, tiles_txt, create_masks=False):
                 tile_cfg['roi'] = {'x': x, 'y': y, 'w': w, 'h': h}
                 tile_cfg['full_img'] = False
                 tile_cfg['max_processes'] = 1
-                tile_cfg['omp_num_threads'] = 1
                 tile_cfg['neighborhood_dirs'] = tile['neighborhood_dirs']
                 tile_cfg['out_dir'] = '../../..'
 


### PR DESCRIPTION
#### Summary

The parameters `'max_processes'` and `'omp_num_threads'` are changed on the fly, preventing the user from setting them.

This pull request fixes the issue.

#### Example :
```
python s2p.py testdata/input_pair/config.json
```

config.json parameters:
```
"matching_algorithm": "msmw2",
"max_processes": 4,
"omp_num_threads": 6
```

CPU architecture information:
```
Architecture:          x86_64
CPU op-mode(s):        32-bit, 64-bit
Byte Order:            Little Endian
CPU(s):                24
```

Before:
```
$ python s2p.py testdata/input_pair/config.json
WARNING: out_dir is a relative path. It is interpreted with respect to testdata/input_pair/config.json location (not cwd)
out_dir is: $S2P_HOME/testdata/input_pair/../../testoutput/output_pair
WARNING: ignoring unknown parameter utm_bbx.
tile size: 350 350
total number of tiles: 4 (2 x 2)

discarding masked tiles...
done 4 / 4 tiles
Elapsed time: 0:00:00.123495

correcting pointing locally...
done 4 / 4 tiles
Elapsed time: 0:00:04.944751

correcting pointing globally...
Elapsed time: 0:00:00.003250

rectifying tiles...
done 4 / 4 tiles
Elapsed time: 0:00:00.412323

running stereo matching...
done 4 / 4 tiles
Elapsed time: 0:01:23.250213

triangulating tiles...
done 4 / 4 tiles
Elapsed time: 0:00:00.712738

computing DSM by tile...
xmin: 359746.161704, xmax: 360105.900786, ymin: 7651554.200378, ymax: 7651922.861785
xmin: 359746.161704, xmax: 360105.900786, ymin: 7651554.200378, ymax: 7651922.861785
xoff: 359746.062000, yoff: 7651922.500000, xsize: 358, ysize: 364
xoff: 359924.562000, yoff: 7651742.000000, xsize: 363, ysize: 377
xmin: 359746.161704, xmax: 360105.900786, ymin: 7651554.200378, ymax: 7651922.861785
xmin: 359746.161704, xmax: 360105.900786, ymin: 7651554.200378, ymax: 7651922.861785
xoff: 359747.062000, yoff: 7651745.500000, xsize: 364, ysize: 384
xoff: 359922.062000, yoff: 7651923.000000, xsize: 366, ysize: 382
done 4 / 4 tiles
Elapsed time: 0:00:00.310246

computing global DSM...

RUN: gdalbuildvrt -vrtnodata nan -input_file_list $S2P_HOME/testdata/input_pair/../../testoutput/output_pair/gdalbuildvrt_input_file_list.txt $S2P_HOME/testdata/input_pair/../../testoutput/output_pair/dsm.vrt
0...10...20...30...40...50...60...70...80...90...100 - done.
0:00:00.038417

RUN: gdal_translate -co TILED=YES -co BIGTIFF=IF_SAFER -projwin 359746.062 7651923.0 360105.562 7651554.0 $S2P_HOME/testdata/input_pair/../../testoutput/output_pair/dsm.vrt $S2P_HOME/testdata/input_pair/../../testoutput/output_pair/dsm.tif
Input file size is 720, 739
0...10...20...30...40...50...60...70...80...90...100 - done.
0:00:00.048640
Elapsed time: 0:00:00.088721

Total elapsed time: 0:01:29.845779
```

After:
```
$ python s2p.py testdata/input_pair/config.json
WARNING: out_dir is a relative path. It is interpreted with respect to testdata/input_pair/config.json location (not cwd)
out_dir is: $S2P_HOME/testdata/input_pair/../../testoutput/output_pair
WARNING: ignoring unknown parameter utm_bbx.
tile size: 350 350
total number of tiles: 4 (2 x 2)

discarding masked tiles...
done 4 / 4 tiles
Elapsed time: 0:00:00.124426

correcting pointing locally...
done 4 / 4 tiles
Elapsed time: 0:00:04.942817

correcting pointing globally...
Elapsed time: 0:00:00.002989

rectifying tiles...
done 4 / 4 tiles
Elapsed time: 0:00:00.311731

running stereo matching...
done 4 / 4 tiles
Elapsed time: 0:00:25.952549

triangulating tiles...
done 4 / 4 tiles
Elapsed time: 0:00:00.712191

computing DSM by tile...
xmin: 359746.161704, xmax: 360105.900786, ymin: 7651554.200378, ymax: 7651922.861785
xmin: 359746.161704, xmax: 360105.900786, ymin: 7651554.200378, ymax: 7651922.861785
xmin: 359746.161704, xmax: 360105.900786, ymin: 7651554.200378, ymax: 7651922.861785
xoff: 359746.062000, yoff: 7651922.500000, xsize: 358, ysize: 364
xoff: 359922.062000, yoff: 7651923.000000, xsize: 366, ysize: 382
xoff: 359924.562000, yoff: 7651742.000000, xsize: 363, ysize: 377
xmin: 359746.161704, xmax: 360105.900786, ymin: 7651554.200378, ymax: 7651922.861785
xoff: 359747.062000, yoff: 7651745.500000, xsize: 364, ysize: 384
done 4 / 4 tiles
Elapsed time: 0:00:00.309828

computing global DSM...

RUN: gdalbuildvrt -vrtnodata nan -input_file_list $S2P_HOME/testdata/input_pair/../../testoutput/output_pair/gdalbuildvrt_input_file_list.txt $S2P_HOME/testdata/input_pair/../../testoutput/output_pair/dsm.vrt
0...10...20...30...40...50...60...70...80...90...100 - done.
0:00:00.047771

RUN: gdal_translate -co TILED=YES -co BIGTIFF=IF_SAFER -projwin 359746.062 7651923.0 360105.562 7651554.0 $S2P_HOME/testdata/input_pair/../../testoutput/output_pair/dsm.vrt $S2P_HOME/testdata/input_pair/../../testoutput/output_pair/dsm.tif
Input file size is 720, 739
0...10...20...30...40...50...60...70...80...90...100 - done.
0:00:00.051668
Elapsed time: 0:00:00.100425

Total elapsed time: 0:00:32.456981
```