### PR TITLE
[refactor] replace piio with rasterio

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,11 +26,11 @@ before_install:
 
 install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then pip install numpy utm bs4 requests; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then pip install GDAL==$(gdal-config --version | awk -F'[.]' '{print $1"."$2}'); fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then pip install rasterio GDAL==$(gdal-config --version | awk -F'[.]' '{print $1"."$2}'); fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then wget http://www.kyngchaos.com/files/software/frameworks/GDAL_Complete-2.1.dmg; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then X=$(echo `hdiutil mount GDAL_Complete-2.1.dmg | tail -1 | awk '{$1=$2=""; print $0}'` | xargs -0 echo) && sudo installer -pkg "${X}/"GDAL\ Complete.pkg -target /; export PATH="/Library/Frameworks/GDAL.framework/Programs:$PATH"; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then pip2 install numpy utm bs4 requests; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then pip2 install GDAL==$(gdal-config --version | awk -F'[.]' '{print $1"."$2}') --global-option build_ext --global-option=`gdal-config --cflags` --global-option build_ext --global-option=-L`gdal-config  --prefix`/unix/lib/; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then pip2 install rasterio GDAL==$(gdal-config --version | awk -F'[.]' '{print $1"."$2}') --global-option build_ext --global-option=`gdal-config --cflags` --global-option build_ext --global-option=-L`gdal-config  --prefix`/unix/lib/; fi
 
 script:
   - make

--- a/makefile
+++ b/makefile
@@ -23,7 +23,7 @@ SRCDIR = c
 BINDIR = bin
 
 # default rule builds only the programs necessary for the test
-default: $(BINDIR) homography sift imscript mgm mgm_multi piio tvl1 lsd
+default: $(BINDIR) homography sift imscript mgm mgm_multi tvl1 lsd
 
 # the "all" rule builds four further correlators
 all: default msmw3 sgbm mgm_multi
@@ -62,13 +62,6 @@ mgm_multi:
 lsd:
 	$(MAKE) -C 3rdparty/lsd
 	cp 3rdparty/lsd/lsd $(BINDIR)
-
-# piio: a required python extension
-piio: s2plib/piio/libiio.so
-
-s2plib/piio/libiio.so: s2plib/piio/setup.py s2plib/piio/freemem.c s2plib/piio/iio.c s2plib/piio/iio.h
-	$(MAKE) -C s2plib/piio
-
 
 #
 # rules for optional "modules": msmw, asift, sgbm, tvl1, etc
@@ -183,7 +176,7 @@ depend:
 
 # rules for cleaning, nothing interesting below this point
 clean: clean_homography clean_asift clean_sift clean_imscript clean_msmw\
-	clean_msmw2 clean_msmw3 clean_tvl1 clean_sgbm clean_mgm clean_piio\
+	clean_msmw2 clean_msmw3 clean_tvl1 clean_sgbm clean_mgm \
 	clean_depend
 
 clean_depend:
@@ -234,8 +227,5 @@ clean_mgm:
 	$(MAKE) -C 3rdparty/mgm clean
 	$(RM) $(BINDIR)/mgm
 
-clean_piio:
-	$(MAKE) -C s2plib/piio clean
-
 .PHONY: default all sift sgbm sgbm_opencv msmw tvl1 imscript clean clean_sift\
-	clean_imscript clean_msmw clean_msmw2 clean_tvl1 clean_sgbm clean_piio test
+	clean_imscript clean_msmw clean_msmw2 clean_tvl1 clean_sgbm test

--- a/s2plib/fusion.py
+++ b/s2plib/fusion.py
@@ -12,6 +12,7 @@ from osgeo import gdal
 gdal.UseExceptions()
 
 from s2plib.config import cfg
+from s2plib import common
 
 
 def average_if_close(x, threshold):

--- a/s2plib/fusion.py
+++ b/s2plib/fusion.py
@@ -11,7 +11,6 @@ import numpy as np
 from osgeo import gdal
 gdal.UseExceptions()
 
-from s2plib import piio
 from s2plib.config import cfg
 
 
@@ -52,8 +51,8 @@ def merge_n(output, inputs, offsets, averaging='average_if_close', threshold=1):
         x[:, :, i] = f.GetRasterBand(1).ReadAsArray() - offsets[i]
         f = None
         if cfg['debug']:
-            piio.write('{}_registered.tif'.format(os.path.splitext(img)[0]),
-                       x[:, :, i] + np.mean(offsets))
+            common.rasterio_write('{}_registered.tif'.format(os.path.splitext(img)[0]),
+                                  x[:, :, i] + np.mean(offsets))
 
     # apply the averaging operator
     if averaging.startswith(('np.', 'numpy.')):

--- a/s2plib/initialization.py
+++ b/s2plib/initialization.py
@@ -12,7 +12,6 @@ import copy
 import shutil
 import numpy as np
 
-from s2plib import piio
 from s2plib import common
 from s2plib import rpc_utils
 from s2plib import masking
@@ -298,9 +297,9 @@ def tiles_full_info(tw, th, tiles_txt, create_masks=False):
                     json.dump(tile_cfg, f, indent=2,default=workaround_json_int64)
 
                 # save the mask
-                piio.write(os.path.join(tile['dir'],
-                                        'cloud_water_image_domain_mask.png'),
-                           mask.astype(np.uint8))
+                common.rasterio_write(os.path.join(tile['dir'],
+                                                   'cloud_water_image_domain_mask.png'),
+                                      mask.astype(np.uint8))
     else:
         if len(tiles_coords) == 1:
             tiles.append(create_tile(tiles_coords[0], neighborhood_coords_dict))

--- a/s2plib/piio
+++ b/s2plib/piio
@@ -1,1 +1,0 @@
-../3rdparty/iio/contrib/piio_packaged/piio

--- a/s2plib/visualisation.py
+++ b/s2plib/visualisation.py
@@ -7,7 +7,6 @@ import numpy as np
 import os
 from osgeo import gdal
 
-from s2plib import piio
 from s2plib import common
 from s2plib import sift
 from s2plib import estimation
@@ -114,7 +113,7 @@ def plot_matches_low_level(im1, im2, matches):
             pass
     # save the output image, and return its path
     outfile = common.tmpfile('.png')
-    piio.write(outfile, out)
+    common.rasterio_write(outfile, out)
     return outfile
 
 


### PR DESCRIPTION
These modifications replace the few [piio](https://github.com/mnhrdt/iio/tree/master/contrib/piio_packaged) calls with equivalent [rasterio](https://rasterio.readthedocs.io/en/stable/) calls.

The goal of this pull request is, similarly to pull request #191, to reduce the number of Python dependencies needed for i/o operations. Right now `s2p` requires `gdal`, `piio` and `rasterio`. After merging this pull request and pull request #191, `s2p` will require only `rasterio`. This will make Python packaging (i.e. enabling `pip install s2p`) easier.