### PR TITLE
[build] update dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,38 +1,20 @@
-# docker for s2p
-# Carlo de Franchis <carlodef@gmail.com>
-
-FROM ubuntu:16.04
+FROM ubuntu:latest
 MAINTAINER Carlo de Franchis <carlodef@gmail.com>
 # https://goo.gl/aypXVx
-ARG DEBIAN_FRONTEND=noninteractive 
+ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y \
     build-essential \
+    cmake \
+    gdal-bin \
     geographiclib-tools \
-    git \
     libfftw3-dev \
     libgdal-dev \
     libgeographic-dev \
     libgeotiff-dev \
     libtiff5-dev \
-    python \
-    python-numpy \
-    python-pip \
-    cmake \
-    software-properties-common \
-    python-software-properties \
-    unzip
-RUN pip install -U pip
-RUN pip install utm bs4 lxml requests
+    python3 \
+    python3-numpy \
+    python3-pip
 
-# Install GDAL 2.x from ubuntugis-stable
-RUN apt-get install dialog apt-utils -y
-RUN add-apt-repository ppa:ubuntugis/ppa -y 
-RUN apt-get update && apt-get install -y \
-    gdal-bin \
-    python-gdal
-
-# Install s2p from MISS3D/s2p
-RUN git clone https://github.com/MISS3D/s2p.git --recursive
-RUN cd s2p && make all
-
-WORKDIR /s2p
+# Install s2p
+RUN pip3 install s2p


### PR DESCRIPTION
This PR updates the Dockerfile with two modifications:
- use `ubuntu:latest` (currently 18.04 LTS) instead of `ubuntu:16.04` as base layer. With this we don't need anymore to add the `ubuntugis-stable` ppa to get a version of gdal >= 2.1
- install s2p with pip