### PR TITLE
Install beautifulsoup4 with lxml parser

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ requirements = ['numpy',
                 'rasterio[s3,test]',
                 'utm',
                 'pyproj',
-                'bs4',
+                'beautifulsoup4[lxml]',
                 'requests']
 
 setup(name="s2p",


### PR DESCRIPTION
In `setup.py`, the package `beautifulsoup` was installed from `bs4`, but as you can on https://pypi.org/project/bs4/:

> [bs4] is a dummy package managed by the developer of Beautiful Soup to prevent name squatting. The official name of PyPI’s Beautiful Soup Python package is beautifulsoup4. This package ensures that if you type pip install bs4 by mistake you will end up with Beautiful Soup.

A problem is also that by default, `beautifulsoup` is not installed with the `lxml` parser. To install it, you need to specify the `extra_requires` `lxml`.

Otherwise, when running `s2p.rpc_utils.kml_roi_process` on a KML file, the following error is raised:
```
bs4.FeatureNotFound: Couldn't find a tree builder with the features you requested: lxml. Do you need to install a parser library?
```

