### PR TITLE
Geojson handling

### DIFF
--- a/s2p/__init__.py
+++ b/s2p/__init__.py
@@ -776,7 +776,7 @@ def read_config_file(config_file):
 
     # ROI paths
     for k in ["roi_kml", "roi_geojson"]:
-        if k in user_cfg and not os.path.isabs(user_cfg[k]):
+        if k in user_cfg and isinstance(user_cfg[k], str) and not os.path.isabs(user_cfg[k]):
             user_cfg[k] = make_path_relative_to_file(user_cfg[k], config_file)
 
     # input paths

--- a/s2p/__init__.py
+++ b/s2p/__init__.py
@@ -774,6 +774,11 @@ def read_config_file(config_file):
                                                          config_file)
         print('out_dir is: {}'.format(user_cfg['out_dir']))
 
+    # ROI paths
+    for k in ["roi_kml", "roi_geojson"]:
+        if k in user_cfg and not os.path.isabs(user_cfg[k]):
+            user_cfg[k] = make_path_relative_to_file(user_cfg[k], config_file)
+
     # input paths
     for img in user_cfg['images']:
         for d in ['img', 'rpc', 'clr', 'cld', 'roi', 'wat']:

--- a/s2p/initialization.py
+++ b/s2p/initialization.py
@@ -73,6 +73,10 @@ def check_parameters(d):
         # this call defines cfg['ll_bbx'] and cfg['utm_bbx'] as side effects
         d['roi'] = rpc_utils.kml_roi_process(d['images'][0]['rpc'],
                                              d['roi_kml'])
+    elif 'roi_geojson' in d:
+        # this call defines cfg['ll_bbx'] and cfg['utm_bbx'] as side effects
+        d['roi'] = rpc_utils.geojson_roi_process(d['images'][0]['rpc'],
+                                                 d['roi_geojson'])
     elif 'prv' in d['images'][0]:
         x, y, w, h = common.get_roi_coordinates(d['images'][0]['img'],
                                                 d['images'][0]['prv'])
@@ -91,7 +95,7 @@ def check_parameters(d):
     # the global config.cfg dictionary, plus the mandatory 'images' and 'roi' or
     # 'roi_utm'
     for k in d.keys():
-        if k not in ['images', 'roi', 'roi_kml', 'roi_utm', 'utm_zone']:
+        if k not in ['images', 'roi', 'roi_kml', 'roi_geojson', 'roi_utm', 'utm_zone']:
             if k not in cfg:
                 print('WARNING: ignoring unknown parameter {}.'.format(k))
 

--- a/s2p/rpc_utils.py
+++ b/s2p/rpc_utils.py
@@ -323,25 +323,34 @@ def kml_roi_process(rpc, kml):
 def geojson_roi_process(rpc, geojson):
     """
     Define a rectangular bounding box in image coordinates
-    from a polygon in a geojson file
+    from a polygon in a geojson file or dict
 
     Args:
         rpc: instance of the rpc_model.RPCModel class, or path to the xml file
-        geojson: file path to a geojson file containing a single polygon
+        geojson: file path to a geojson file containing a single polygon,
+            or content of the file as a dict.
+            The geojson's top-level type should be either FeatureCollection,
+            Feature, or Polygon.
 
     Returns:
         x, y, w, h: four integers defining a rectangular region of interest
             (ROI) in the image. (x, y) is the top-left corner, and (w, h)
             are the dimensions of the rectangle.
     """
-    # extract lon lat from geojson
-    with open(geojson, 'r') as f:
-        a = json.load(f)
+    # extract lon lat from geojson file or dict
+    if isinstance(geojson, str):
+        with open(geojson, 'r') as f:
+            a = json.load(f)
+    else:
+        a = geojson
 
     if a["type"] == "FeatureCollection":
         a = a["features"][0]
 
-    ll_poly = np.array(a["geometry"]["coordinates"][0])
+    if a["type"] == "Feature":
+        a = a["geometry"]
+
+    ll_poly = np.array(a["coordinates"][0])
     box_d = roi_process(rpc, ll_poly)
     return box_d
 


### PR DESCRIPTION
This PR adds the ability to provide a `geojson` file in the `config.json` to specify the region of interest (done in 034160a)

It also fixes two small bugs that impacted the `roi_kml` functionality:
- The path to `roi_kml` was not made relative to the `config.json` file, as it is already done for the output directory and for the input image paths. Fixed by 805d02d.
- The parsing of the file given in `roi_kml` was done in such a way that only the first 4 points of the given polygon were taken into account to compute the bounding box. Fixed by 6005a82.